### PR TITLE
Adding `frontend-worship-decisions` image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 
 x-logging:
   &default-logging
@@ -9,7 +9,7 @@ x-logging:
 
 services:
   frontend:
-    image: lblod/frontend-public-decisions:1.4.0
+    image: lblod/frontend-worship-decisions:0.1.0
     volumes:
       - ./config/frontend:/config
     labels:
@@ -100,7 +100,7 @@ services:
   migrations:
     image: semtech/mu-migrations-service:0.6.0
     environment:
-      MU_SPARQL_TIMEOUT: '300'
+      MU_SPARQL_TIMEOUT: "300"
     links:
       - virtuoso:database
     volumes:
@@ -164,31 +164,31 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-################################################################################
-# DELTAS
-################################################################################
+  ################################################################################
+  # DELTAS
+  ################################################################################
   submissions-consumer:
-      image: lblod/delta-consumer:0.0.5
-      environment:
-        DCR_SYNC_BASE_URL: 'https://loket.lblod.info/'
-        DCR_SERVICE_NAME: 'submissions-consumer'
-        DCR_SYNC_FILES_PATH: '/sync/submissions/files'
-        DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/SubmissionsCacheGraphDump"
-        DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/submissions"
-        DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/submissions-consumer"
-        DCR_DISABLE_INITIAL_SYNC: 'true'
-        DCR_KEEP_DELTA_FILES: 'true'
-        DCR_DELTA_FILE_FOLDER: '/consumer-files'
-        DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/sumbissionFileSyncing"
-        INGEST_GRAPH: "http://mu.semte.ch/graphs/access-for-role/PubliekeBesluitendatabank-BesluitendatabankLezer"
-        BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: 'true'
-        FILE_SYNC_GRAPH: "http://mu.semte.ch/graphs/original-physical-files-data"
-      volumes:
-        - ./config/submissions-consumer/submissions-dispatching:/config/triples-dispatching/custom-dispatching
-        - ./data/files/consumer-files/submissions:/consumer-files/
-        - ./data/files:/share
-      restart: always
-      logging: *default-logging
+    image: lblod/delta-consumer:0.0.5
+    environment:
+      DCR_SYNC_BASE_URL: "https://loket.lblod.info/"
+      DCR_SERVICE_NAME: "submissions-consumer"
+      DCR_SYNC_FILES_PATH: "/sync/submissions/files"
+      DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/SubmissionsCacheGraphDump"
+      DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/submissions"
+      DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/submissions-consumer"
+      DCR_DISABLE_INITIAL_SYNC: "true"
+      DCR_KEEP_DELTA_FILES: "true"
+      DCR_DELTA_FILE_FOLDER: "/consumer-files"
+      DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/sumbissionFileSyncing"
+      INGEST_GRAPH: "http://mu.semte.ch/graphs/access-for-role/PubliekeBesluitendatabank-BesluitendatabankLezer"
+      BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: "true"
+      FILE_SYNC_GRAPH: "http://mu.semte.ch/graphs/original-physical-files-data"
+    volumes:
+      - ./config/submissions-consumer/submissions-dispatching:/config/triples-dispatching/custom-dispatching
+      - ./data/files/consumer-files/submissions:/consumer-files/
+      - ./data/files:/share
+    restart: always
+    logging: *default-logging
   files-consumer:
     image: lblod/delta-consumer-file-sync-submissions:0.5.1
     environment:


### PR DESCRIPTION
DL-4282

Adding the frontend-worship-decisions to the docker-compose.yml

Note : Login environment information needs to be received and modified before merging.

Do we need ? 
If so, `PUBLIC_GRAPH` and `FILE_GRAPH` needs to be modified too right ? (as ACL)
 ```
enrich-submission:
    image: lblod/enrich-submission-service:0.12.0
    volumes:
      - ./config/semantic-forms:/share/semantic-forms
      - ./data/files/submissions:/share/submissions
    environment:
      ACTIVE_FORM_FILE: "share://semantic-forms/20220721150218-forms.ttl"
      PUBLIC_GRAPH: "http://mu.semte.ch/graphs/access-for-role/PubliekeBesluitendatabank-BesluitendatabankLezer"
      FILE_GRAPH: "http://mu.semte.ch/graphs/access-for-role/PubliekeBesluitendatabank-BesluitendatabankLezer"
    labels:
      - "logging=true"
    restart: always
    logging: *default-logging
