### PR TITLE
Migration adding scheme to all bestuurseenheden

### DIFF
--- a/config/migrations/2022/20221208180123-add-scheme-to-bestuurseenheden.sparql
+++ b/config/migrations/2022/20221208180123-add-scheme-to-bestuurseenheden.sparql
@@ -1,0 +1,14 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+INSERT {
+    GRAPH ?g {
+        ?s skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083>.
+        ?s skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083>.
+    }
+} WHERE {
+    GRAPH ?h {
+        ?s a besluit:Bestuurseenheid .
+    }
+    BIND(?h as ?g)
+}


### PR DESCRIPTION
This migration makes sure all bestuurseenheden have a scheme. This fixes not all bestuurseenheden being visible in the frontend bestuurseenheden search dropdown. We might want to consider just removing the concept scheme in the form.ttl if it applies to all bestuurseenheden anyway. That would prevent these issues in the future