### PR TITLE
Bump consumer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,7 +155,7 @@ services:
   # DELTAS
   ################################################################################
   submissions-consumer:
-    image: lblod/delta-consumer:0.0.12
+    image: lblod/delta-consumer:0.0.15
     environment:
       DCR_SYNC_BASE_URL: "https://loket.lblod.info/"
       DCR_SYNC_LOGIN_ENDPOINT: 'https://loket.lblod.info/sync/worship-submissions/login' # don't forget DCR_SECRET_KEY in docker-compose.override.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,6 +147,8 @@ services:
     image: lblod/worship-submissions-graph-dispatcher-service:0.5.1
     environment:
       ORG_GRAPH_SUFFIX: "LoketLB-databankEredienstenGebruiker"
+      SUDO_QUERY_RETRY: "true"
+      SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: "404,500"
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
The consumer gets stuck if a file is downloaded to be processed and the service is restarted before the end of the processing. The new version of the consumer fixes it (https://github.com/lblod/delta-consumer/pull/9).