### PR TITLE
Add mock login for all bestuurseenheden

### DIFF
--- a/config/migrations/2023/20230210200356-add-mock-users-for-all-bestuurseenheden.sparql
+++ b/config/migrations/2023/20230210200356-add-mock-users-for-all-bestuurseenheden.sparql
@@ -1,0 +1,26 @@
+PREFIX mu:      <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?account ext:sessionRole "LoketLB-databankEredienstenGebruiker" .
+  }
+
+  GRAPH ?g {
+    ?account ext:sessionRole "LoketLB-databankEredienstenGebruiker" .
+  }
+}
+WHERE {
+  ?bestuurseenheid a besluit:Bestuurseenheid ;
+    mu:uuid ?uuid .
+
+  ?person a foaf:Person ;
+    foaf:account ?account ;
+    foaf:member ?bestuurseenheid .
+
+  BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", ?uuid)) AS ?g)
+
+  FILTER NOT EXISTS { ?account ext:sessionRole "LoketLB-databankEredienstenGebruiker" }
+}


### PR DESCRIPTION
Adds mock-login for bestuurseenheden that do not yet have the "LoketLB-databankEredienstenGebruiker" session property.