### PR TITLE
Add service that creates mock accounts automatically

### DIFF
--- a/config/mock-login/rules.json
+++ b/config/mock-login/rules.json
@@ -1,0 +1,7 @@
+{
+  "rules": [
+    {
+      "sessionRole": "LoketLB-databankEredienstenGebruiker"
+    }
+  ]
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -46,3 +46,5 @@ services:
     restart: "no"
   submissions-dispatcher:
     restart: "no"
+  update-bestuurseenheid-mock-login:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,6 +182,14 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  update-bestuurseenheid-mock-login:
+    image: lblod/update-bestuurseenheid-mock-login-service:0.1.0
+    volumes:
+      - ./config/mock-login:/config
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
   ################################################################################
   # DELTAS
   ################################################################################


### PR DESCRIPTION
This PR adds a service that automatically creates missing mock-login accounts (and removed outdated ones). It becomes handy now that admin units arrive to the application via a delta sync.

About the technical choices made in the service:
1. I chose a cron job trigger type and not a delta trigger type because the cron job way is lighter on the stack and to implement, and mock accounts are not so urgent to get so we don't need it right away when the bestuur arrived in the stack
2. A config file has to be added in the application using the service. That way, the service can be reused over multiple stacks working with different roles.

The service can be found here https://github.com/lblod/update-bestuurseenheid-mock-login-service