### PR TITLE
[Melding functionaliteit] Adding core features

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -1,5 +1,6 @@
 alias Acl.Accessibility.Always, as: AlwaysAccessible
 alias Acl.Accessibility.ByQuery, as: AccessByQuery
+alias Acl.GraphSpec.Constraint.Resource.NoPredicates, as: NoPredicates
 alias Acl.GraphSpec.Constraint.Resource, as: ResourceConstraint
 alias Acl.GraphSpec, as: GraphSpec
 alias Acl.GroupSpec, as: GroupSpec
@@ -61,7 +62,8 @@ defmodule Acl.UserGroups.Config do
                         "http://mu.semte.ch/vocabularies/ext/AuthenticityType",
                         "http://www.w3.org/2004/02/skos/core#ConceptScheme",
                         "http://www.w3.org/2004/02/skos/core#Concept",
-                        "http://www.w3.org/ns/prov#Location"
+                        "http://www.w3.org/ns/prov#Location",
+                        "http://mu.semte.ch/graphs/system/email"
                       ]
                     } } ] },
       %GroupSpec{
@@ -109,7 +111,21 @@ defmodule Acl.UserGroups.Config do
                         "http://www.w3.org/ns/prov#Location"
                       ]
                     } } ] },
-
+      # // subscribe for email notifications
+      %GroupSpec{
+        name: "subscribed-for-notifications",
+        useage: [:read, :write, :read_for_write],
+      access: access_by_role("LoketLB-databankEredienstenGebruiker"),
+        graphs: [ %GraphSpec{
+                    graph: "http://mu.semte.ch/graphs/organizations/",
+                    constraint: %ResourceConstraint{
+                      resource_types: [ "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid" ],
+                      predicates: %NoPredicates{
+                        except: [
+                          "http://mu.semte.ch/vocabularies/ext/mailAdresVoorNotificaties",
+                          "http://mu.semte.ch/vocabularies/ext/wilMailOntvangen"
+                        ] }
+                    } } ] },
       # // dashboard users
       %GroupSpec{
         name: "dashboard-users",

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -67,11 +67,7 @@ defmodule Dispatcher do
   # General/Shared
   ###############################################################
 
-  get "/bestuurseenheden/*path", @json do
-    Proxy.forward conn, path, "http://cache/bestuurseenheden/"
-  end
-
-  patch "/bestuurseenheden/*path", @json do
+  match "/bestuurseenheden/*path", @json do
     Proxy.forward conn, path, "http://cache/bestuurseenheden/"
   end
 

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -71,6 +71,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/bestuurseenheden/"
   end
 
+  patch "/bestuurseenheden/*path", @json do
+    Proxy.forward conn, path, "http://cache/bestuurseenheden/"
+  end
+
   get "/werkingsgebieden/*path", @json do
     Proxy.forward conn, path, "http://cache/werkingsgebieden/"
   end

--- a/config/migrations/2023/20230605143124-mailbox-folders.sparql
+++ b/config/migrations/2023/20230605143124-mailbox-folders.sparql
@@ -1,0 +1,44 @@
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/system/email> {
+    <http://data.lblod.info/id/mailboxes/1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#Mailbox>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "cf9cb7e4-9a00-4855-9ee0-e8e3bbeba9e9";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> <http://data.lblod.info/id/mail-folders/1>;
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> <http://data.lblod.info/id/mail-folders/2>;
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> <http://data.lblod.info/id/mail-folders/3>;
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> <http://data.lblod.info/id/mail-folders/4>;
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> <http://data.lblod.info/id/mail-folders/5>;
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> <http://data.lblod.info/id/mail-folders/6>.
+
+    <http://data.lblod.info/id/mail-folders/1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "891c67e5-4719-47f8-aec2-d898ba2c09e8";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#title> "inbox";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#description> "Your incoming mail goes here.".
+
+    <http://data.lblod.info/id/mail-folders/2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "786a8cb0-4452-40f5-b8d8-046dd2d63281";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#title> "outbox";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#description> "Your outgoing mail goes here.".
+
+    <http://data.lblod.info/id/mail-folders/3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "a6fb03f9-11be-4401-9d8f-b4dc0e9df5ee";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#title> "sentbox";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#description> "Your sent mail goes here.".
+
+
+    <http://data.lblod.info/id/mail-folders/4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "a430a848-e595-49fa-bc11-f5579605877f";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#title> "sending";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#description> "Your mail goes here while being sent.".
+
+    <http://data.lblod.info/id/mail-folders/5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "0cb108a9-1c0d-4c0a-bf53-60e304116e47";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#title> "drafts";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#description> "Your draft goes here.".
+
+    <http://data.lblod.info/id/mail-folders/6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#Folder>;
+       <http://mu.semte.ch/vocabularies/core/uuid> "70c0baba-17a0-11eb-adc1-0242ac120002";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#title> "failbox";
+       <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#description> "Your email that failed while sending goes here.".
+
+  }
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,3 +52,7 @@ services:
     restart: "no"
   op-public-consumer:
     restart: "no"
+  worship-submissions-email-notification-service:
+    restart: "no"
+  deliver-email-service:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./scripts/project:/app/scripts/
     restart: "no"
   frontend:
-    image: lblod/frontend-worship-decisions:0.6.0
+    image: lblod/frontend-worship-decisions:0.7.0
     volumes:
       - ./config/frontend:/config
     labels:
@@ -270,7 +270,7 @@ services:
     restart: always
     logging: *default-logging
   worship-submissions-email-notification-service:
-    image: lblod/worship-submissions-email-notification-service:latest
+    image: lblod/worship-submissions-email-notification-service:1.0.0
     environment:
       RUN_INTERVAL: 5
       OUTBOX_FOLDER_URI: "http://data.lblod.info/id/mail-folders/2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -261,3 +261,18 @@ services:
     labels:
       - "logging=true"
     logging: *default-logging
+  deliver-email-service:
+    image: redpencil/deliver-email-service:0.2.0
+    environment:
+      MAILBOX_URI: "http://data.lblod.info/id/mailboxes/1"
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
+  worship-submissions-email-notification-service:
+    image: lblod/worship-submissions-email-notification-service:latest
+    environment:
+      RUN_INTERVAL: 5
+      OUTBOX_FOLDER_URI: "http://data.lblod.info/id/mail-folders/2"
+      FROM_EMAIL_ADRESS: "Agentschap Binnenlands Bestuur Vlaanderen <noreply-binnenland@vlaanderen.be>"
+      WORSHIP_DECISIONS_APP_BASEURL: "https://databankerediensten.lokaalbestuur.vlaanderen.be/"


### PR DESCRIPTION
# Description
DL-5177
DL-5179

This PR is about adding the melding functionaliteit feature.

- Adding patch route for bestuurseenheden.
- Adding mu-auth rights
- Adding migration for mailboxes
- Adding services to the stack


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services (not included yet)

- [worship-submissions-email-notification-service](https://github.com/lblod/worship-submissions-email-notification-service)
- deliver-email-service

# How to test

1. Log as any administrative unit.
2. Click on "Ontvang mails bij nieuwe inzendingen" .
![Screenshot 2023-05-31 at 12-20-18 Erediensten Toezichtsdatabank](https://github.com/lblod/frontend-worship-decisions/assets/38471754/36033dad-9e7e-403e-bf39-d0403867f7ef)
3. A modal should popup where you can set an e-mail address.
4. Filling the address and validating should update the email value and set wilMailOntvangen  to `true` from the bestuurseenheid (administrative-unit).

# What to check

- Email and wilMailOntvangen should be updated for bestuurseenheid.
- Typo issues.

# Links to other PR's

- https://github.com/lblod/frontend-worship-decisions/pull/9

# Notes

- Bump frontend when merged
- Add worship-submissions-email-notification-service when merged
