### PR TITLE
Fixing bestuurseenheid filter

### DIFF
--- a/config/migrations/2023/20230720170130-attach-conceptSchemes-to-worship-units.sparql
+++ b/config/migrations/2023/20230720170130-attach-conceptSchemes-to-worship-units.sparql
@@ -1,0 +1,57 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+    ?representatiefOrgaan skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
+    }
+}
+WHERE {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+    ?representatiefOrgaan a ere:RepresentatiefOrgaan .
+    }
+}
+
+;
+
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuurVanDeEredienst skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
+    }
+}
+WHERE {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuurVanDeEredienst a ere:BestuurVanDeEredienst .
+    }
+}
+
+;
+
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+    ?centraalBestuurVanDeEredienst skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
+    }
+}
+WHERE {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+    ?centraalBestuurVanDeEredienst a ere:CentraalBestuurVanDeEredienst .
+    }
+}
+
+;
+
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuurseenheid skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
+        skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
+    }
+}
+WHERE {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuurseenheid a besluit:Bestuurseenheid .
+    }
+}

--- a/config/reasoner/op2dl/main/mapping.n3
+++ b/config/reasoner/op2dl/main/mapping.n3
@@ -22,23 +22,28 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 # Add missing datatypes
 {
-  ?s a ere:BestuurVanDeEredienst
+  ?s a ere:BestuurVanDeEredienst 
 } => {
-  ?s a besluit:Bestuurseenheid
+  ?s a besluit:Bestuurseenheid ;
+     skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
+     skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
 }.
 
 {
-  ?s a ere:CentraalBestuurVanDeEredienst
+  ?s a ere:CentraalBestuurVanDeEredienst 
 } => {
-  ?s a besluit:Bestuurseenheid
+  ?s a besluit:Bestuurseenheid ;
+     skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
+     skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
 }.
 
 {
-  ?s a ere:RepresentatiefOrgaan
-}=> {
-  ?s
-    a besluit:Bestuurseenheid;
-    besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213>.
+  ?s a ere:RepresentatiefOrgaan 
+} => {
+  ?s a besluit:Bestuurseenheid ;
+     besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> ;
+     skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
+     skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
 }.
 
 

--- a/config/reasoner/op2dl/main/query.n3q
+++ b/config/reasoner/op2dl/main/query.n3q
@@ -86,6 +86,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 }.
 
 {
+  ?s 
+    a ere:BestuurVanDeEredienst;
+    skos:topConceptOf ?topConceptOf;
+    skos:inScheme ?inScheme.
+} => {
+  ?s 
+    skos:topConceptOf ?topConceptOf;
+    skos:inScheme ?inScheme.
+}.
+
+{
   ?s
     besluit:classificatie
       ?classificatie;
@@ -154,6 +165,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 } => {
   ?s
     skos:prefLabel ?label.
+}.
+
+{
+  ?s 
+    a ere:RepresentatiefOrgaan;
+    skos:topConceptOf ?topConceptOf;
+    skos:inScheme ?inScheme.
+} => {
+  ?s 
+    skos:topConceptOf ?topConceptOf;
+    skos:inScheme ?inScheme.
 }.
 
 {
@@ -236,6 +258,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 } => {
   ?s
     skos:prefLabel ?label.
+}.
+
+{
+  ?s 
+    a ere:CentraalBestuurVanDeEredienst;
+    skos:topConceptOf ?topConceptOf;
+    skos:inScheme ?inScheme.
+} => {
+  ?s 
+    skos:topConceptOf ?topConceptOf;
+    skos:inScheme ?inScheme.
 }.
 
 {


### PR DESCRIPTION
# Description
DL-5029

This PR fixes the bestuurseenheid filter to show all worship units from OP consumer. It attaches conceptSchemes with the reasoner and adds missing conceptSchemes with a migration.

- Adding conceptScheme in the reasoner (handles the case when we add new units and sync).
- Adding migration where we attach the conceptScheme to worship units (to avoid doing full resync).

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- [Reasoning-service](https://github.com/eyereasoner/reasoning-service)
- [op-public-consumer](https://github.com/lblod/delta-consumer)
- [seach-query-management](https://github.com/lblod/toezicht-search-query-management-service)

# How to test 

1. Clone the project and checkout on that branch
2. Follow readme section `Running the dev. setup` to  `steps` , any extra ingestion is not needed since we are just manipulating consumed OP data.
3. Restart the following service `search-query-management`
4. It should show all worship units in the bestuurseenheid filter when login as lezer ABB

Expected result : 

![Screenshot 2023-07-20 at 16-36-41 Erediensten Toezichtsdatabank](https://github.com/lblod/app-worship-decisions-database/assets/38471754/0dd1eb21-27f1-4b12-9057-c3fe89de2d5b)

# What to check

- If a new bestuurseenheid from OP gets the conceptSchemes attached.

# Links to other PR's

- N/A

# Notes

Case re-sync or adding a new bestuurseenheid in OP : 
- drc restart search-query-management

Case no sync (migration) :
- drc restart migrations then drc restart search-query-management (migrations can take some time to run and restarting both could not refresh the filter if the migration was not DONE
