### PR TITLE
[ Filter-form ] Adding new filter-form field

### DIFF
--- a/config/search-query/filter-form.ttl
+++ b/config/search-query/filter-form.ttl
@@ -68,6 +68,12 @@ fields:2c6ae26c-c3de-4bbc-9021-9cb45b886742 a form:PropertyGroup;
     sh:order 7 ;
     sh:group fields:7fe1a020-7e48-44c2-b7f0-6b7943ddff3e .
 
+fields:9825b9c3-f942-4ba9-bd6c-5201dbae24b8 a form:PropertyGroup;
+    mu:uuid "9825b9c3-f942-4ba9-bd6c-5201dbae24b8";
+    sh:description "date filter";
+    sh:order 8 ;
+    sh:group fields:7fe1a020-7e48-44c2-b7f0-6b7943ddff3e .
+
 ##########################################################
 #  END property-groups
 ##########################################################
@@ -223,6 +229,22 @@ fields:db613412-727e-486f-8a11-7fc25abed640 a form:Field ;
 ##########################################################
 
 ##########################################################
+# START unique session date 
+##########################################################
+fields:b6c4c973-b15e-4ffd-861f-1198e3fef1f0 a form:Field ;
+ mu:uuid "b6c4c973-b15e-4ffd-861f-1198e3fef1f0" ;
+ sh:name "Zoeken op specifieke datum zitting / besluit" ;
+ sh:order 111 ;
+ search:emberQueryParameterKey "sessionDateTime" ;
+ sh:path searchToezicht:sessionDateTime ;
+ form:displayType displayTypes:dateTime ;
+ sh:group fields:9825b9c3-f942-4ba9-bd6c-5201dbae24b8 .
+
+##########################################################
+#  END unique session date
+##########################################################
+
+##########################################################
 #  END fields
 ##########################################################
 
@@ -246,7 +268,10 @@ fieldGroups:filter a form:FieldGroup ;
                 fields:edcd6b86-2a9c-4c2a-a283-e536f49fbe7b,
 
                 ### Session Date From-To datepicker
-                fields:6565db60-c0d3-4878-b240-35d661b3ca86.
+                fields:6565db60-c0d3-4878-b240-35d661b3ca86,
+
+                ### Unique Session Date from date
+                fields:b6c4c973-b15e-4ffd-861f-1198e3fef1f0.
 
 form: a form:Form ;
     mu:uuid "6b70a6f0-cce2-4afe-81f5-5911f45b0b27" ;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./scripts/project:/app/scripts/
     restart: "no"
   frontend:
-    image: lblod/frontend-worship-decisions:0.8.0
+    image: lblod/frontend-worship-decisions:0.9.0
     volumes:
       - ./config/frontend:/config
     labels:


### PR DESCRIPTION
# Description
DL-5329

This PR essentially adds a new field where the user is now allowed to perform filtering based on one date (without time).

Users (context ERE) know specific dates they want to filter for. Currently if they’re looking for documents from 01/01/2023 they have to filter 01/01/2023-02/01/2023 which gives them way more results to look at than they need, prolonging and hindering their search. Ideally they should just select 1 date in the filters instead of having to select a start- and end date.


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- [search-query-management](https://github.com/lblod/toezicht-search-query-management-service)

# How to test 

1. Run on both branches from backend and frontend (They have the same name)
2. Log as any administrative units that have a lot of submission (e.g : Aalst)
3. Use the filter by typing one date.
4. It should filter by the date without the time


# Links to other PR's

- https://github.com/lblod/frontend-worship-decisions/pull/12

# Notes

drc restart search-query-management

To be merged with https://github.com/lblod/frontend-worship-decisions/pull/12
