### PR TITLE
Adding new report "Generate worship services without email notifications"

### DIFF
--- a/config/reports/index.js
+++ b/config/reports/index.js
@@ -1,7 +1,9 @@
 import submissionsReport from './submissions';
 import linksBetweenWorshipServicesAndAdminUnitsReport from './links-between-worship-services-and-admin-units-report';
+import worshipServicesWithoutEmailNotifications from './worship-services-without-email-notifications';
 
 export default [
   submissionsReport,
-  linksBetweenWorshipServicesAndAdminUnitsReport
+  linksBetweenWorshipServicesAndAdminUnitsReport,
+  worshipServicesWithoutEmailNotifications
 ];

--- a/config/reports/worship-services-without-email-notifications.js
+++ b/config/reports/worship-services-without-email-notifications.js
@@ -1,0 +1,56 @@
+import { generateReportFromData, batchedQuery } from '../helpers.js';
+
+export default {
+  cronPattern: '0 0 5 * * 0', // at 05:00 on Sunday 
+  name: 'worshipServicesWithoutEmailNotifications',
+  execute: async () => {
+    const reportData = {
+      title: `List of worship services without email notifications`,
+      description: `Report listing of all worship services (RO, EB, CB) without emails set`,
+      filePrefix: `worship-services-without-email-notifications`,
+    };
+    console.log('Generate worship services without email notifications report');
+
+    /**
+     * Query that extracts all worship services without emails (ext:mailAdresVoorNotificaties).
+     **/
+    const queryString = `
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+    PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    
+    SELECT DISTINCT ?worshipAdministrativeUnit ?worshipLabel ?worshipClassification
+    WHERE {
+      VALUES ?worshipType {
+        ere:BestuurVanDeEredienst
+        ere:CentraalBestuurVanDeEredienst
+        ere:RepresentatiefOrgaan
+      }
+      ?worshipAdministrativeUnit a ?worshipType ;
+        skos:prefLabel ?worshipLabel ;
+        besluit:classificatie/skos:prefLabel ?worshipClassification .
+    
+      FILTER NOT EXISTS {
+        ?worshipAdministrativeUnit ext:wilMailOntvangen ?hasEmailNotifications ; 
+                                   ext:mailAdresVoorNotificaties ?emailAddress .
+      }
+    }
+    ORDER BY ?worshipType    
+    `;
+    const queryResponse = await batchedQuery(queryString);
+    const data = queryResponse.results.bindings.map((unit) => {
+      return {
+        worshipAdministrativeUnit: unit.worshipAdministrativeUnit.value,
+        worshipLabel: unit.worshipLabel.value,
+        worshipClassification: unit.worshipClassification.value,
+      };
+    });
+
+    await generateReportFromData(data, [
+      'worshipAdministrativeUnit',
+      'worshipLabel',
+      'worshipClassification',
+    ], reportData);
+  }
+};


### PR DESCRIPTION
# Description
DL-5416

This PR adds a new report named : worshipServicesWithoutEmailNotifications that triggers every sunday at 05:00 am

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- https://github.com/lblod/loket-report-generation-service

# How to test 

1. Use this branch to trigger the report with : 

Note : rebind the port of the report-generation service in your docker-compose.override.yml 

```yml
  report-generation:
    links:
      - virtuoso:database  # we need to because performance
    ports:
      - 9999:80
```

```bash
curl -X POST \
  -H "Content-Type: application/vnd.api+json" \
  -d '{
    "data": {
      "attributes": {
        "reportName": "worshipServicesWithoutEmailNotifications"
      }
    }
  }' \
  http://localhost:9999/reports
```

expected : ` {"data":{"type":"report-generation-tasks","attributes":{"status":"success"}}}`

3. It should generate the report log `report-generation`
4. You can also check the dashboard-login to see if it has the report when login as lezer ABB in the frontend

# What to check

- If the reports contains only worship units 

# Links to other PR's

- N/A

# Notes

drc restart report-generation