### PR TITLE
Service maintenance

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,7 +177,7 @@ services:
       - virtuoso:database # Because mu-auth is bottleneck in heavy reports
     volumes:
       - ./data/files:/share
-      - ./config/reports:/app/reports
+      - ./config/reports:/config
     labels:
       - "logging=true"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     labels:
       - "logging=true"
   identifier:
-    image: semtech/mu-identifier:1.9.1
+    image: semtech/mu-identifier:1.10.1
     links:
       - dispatcher:dispatcher
     labels:
@@ -48,7 +48,7 @@ services:
     restart: always
     logging: *default-logging
   deltanotifier:
-    image: cecemel/delta-notifier:0.2.0-beta.2
+    image: semtech/mu-delta-notifier:0.2.0
     volumes:
       - ./config/delta:/config
     labels:
@@ -56,7 +56,7 @@ services:
     restart: always
     logging: *default-logging
   virtuoso:
-    image: redpencil/virtuoso:1.0.0
+    image: redpencil/virtuoso:1.2.0-rc.1
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"
@@ -69,7 +69,7 @@ services:
     restart: always
     logging: *default-logging
   resource:
-    image: semtech/mu-cl-resources:1.20.0
+    image: semtech/mu-cl-resources:1.23.0
     environment:
       CACHE_CLEAR_PATH: "http://cache/.mu/clear-keys"
     volumes:
@@ -93,7 +93,7 @@ services:
     restart: always
     logging: *default-logging
   dashboard-login:
-    image: semtech/mu-login-service:2.9.1
+    image: semtech/mu-login-service:3.0.0
     links:
       - database:database
     labels:
@@ -101,7 +101,7 @@ services:
     restart: always
     logging: *default-logging
   database:
-    image: semtech/mu-authorization:0.6.0-beta.7
+    image: semtech/mu-authorization:0.6.0-beta.8
     environment:
       MU_SPARQL_ENDPOINT: "http://virtuoso:8890/sparql"
     volumes:
@@ -119,7 +119,7 @@ services:
     restart: always
     logging: *default-logging
   migrations:
-    image: semtech/mu-migrations-service:0.6.0
+    image: semtech/mu-migrations-service:0.9.0
     environment:
       MU_SPARQL_TIMEOUT: "300"
     links:
@@ -131,7 +131,7 @@ services:
     restart: always
     logging: *default-logging
   file:
-    image: semtech/mu-file-service:3.2.0
+    image: semtech/mu-file-service:3.3.2
     volumes:
       - ./data/files:/share
     labels:
@@ -147,7 +147,7 @@ services:
     restart: always
     logging: *default-logging
   enrich-submission:
-    image: lblod/enrich-submission-service:1.4.0
+    image: lblod/enrich-submission-service:1.8.0
     volumes:
       - ./config/semantic-forms:/share/semantic-forms
       - ./data/files/submissions:/share/submissions
@@ -170,7 +170,7 @@ services:
     restart: always
     logging: *default-logging
   report-generation:
-    image: lblod/loket-report-generation-service:0.5.0
+    image: lblod/loket-report-generation-service:0.7.0
     environment:
       DEFAULT_GRAPH: "http://mu.semte.ch/graphs/reports"
     links:
@@ -229,7 +229,7 @@ services:
   # OP PUBLIC CONSUMER
   ################################################################################
   reasoner:
-    image: eyereasoner/reasoning-service:increased-stack-limit
+    image: eyereasoner/reasoning-service:1.0.4
     volumes:
       - ./config/reasoner:/config
     restart: always
@@ -262,7 +262,7 @@ services:
       - "logging=true"
     logging: *default-logging
   deliver-email-service:
-    image: redpencil/deliver-email-service:0.2.0
+    image: redpencil/deliver-email-service:0.3.3
     environment:
       MAILBOX_URI: "http://data.lblod.info/id/mailboxes/1"
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,7 @@ services:
     restart: always
     logging: *default-logging
   enrich-submission:
-    image: lblod/enrich-submission-service:1.8.0
+    image: lblod/enrich-submission-service:1.9.0
     volumes:
       - ./config/semantic-forms:/share/semantic-forms
       - ./data/files/submissions:/share/submissions


### PR DESCRIPTION
[DL-5672]

Before embarking on more drastic changes to the application, we want to bring all services up to date. This PR aims to achieve that.

**Things worthy of note:**

* Config for the `report-generation-service` was moved to the `/config` mount point due to the use of a newer `mu-javascript-template`
* A new version of the `enrich-submission-service` was made and bumped here to be able to read data from graphs in this application that are different from the ones in Loket