### PR TITLE
Adjusting dispatch for inactive Centrale Bestuuren in Meerjarenplan(aanpasing) / Budget(wijziging) / Jaarrekening submissions made by EB's

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,7 @@ services:
     restart: always
     logging: *default-logging
   submissions-dispatcher:
-    image: lblod/worship-submissions-graph-dispatcher-service:0.14.0
+    image: lblod/worship-submissions-graph-dispatcher-service:0.15.0-rc.1
     environment:
       ORG_GRAPH_SUFFIX: "LoketLB-databankEredienstenGebruiker"
       SUDO_QUERY_RETRY: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,7 @@ services:
     restart: always
     logging: *default-logging
   submissions-dispatcher:
-    image: lblod/worship-submissions-graph-dispatcher-service:0.15.0-rc.1
+    image: lblod/worship-submissions-graph-dispatcher-service:0.15.0
     environment:
       ORG_GRAPH_SUFFIX: "LoketLB-databankEredienstenGebruiker"
       SUDO_QUERY_RETRY: "true"


### PR DESCRIPTION
# Description

DL-5707

This PR adjusts rules for Meerjarenplan(aanpasing) / Budget(wijziging) / Jaarrekening submissions targeted to CB (Centrale Bestuur) when made by EB (Bestuur van de Eredienst). It's possible that over time Centrale bestuur goes inactive thus, submissions wont be consulted.

These rules adjustments are then made to "verify" if the CB is still active with the predicate `regorg:orgStatus` :

- <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> Goes for "Niet actief"
- <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> Goes for "Actief"

Inactive CB will be treated as not attached to the EB, so it will be handled by the rule "EB has no CB".

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

:warning: I suggest to make a backup if you tweak the status of the CB

1. Setup consumer/producer stack (Loket/Worship-decisions-database) + add the RC image of this service in docker-compose.override
2. Create submissions Jaarrening / Budget(wijziging) - Indiening bij Centraal bestuur of Representatief orgaan & Budget(wijziging)- Indiening bij toezichthoudende gemeente of provincie / Meerjarenplan(aanpassing) with a Bestuur van de Eredienst with an active/inactive Centrale Bestuur and without a Centrale Bestuur
3. Inactive ones should be considered as without a Eredienst Bestuur where active should flow like before except the dispatcher rule will now check if the Centrale Bestuur is active.

#### Here's some useful information :

- https://data.lblod.info/id/besturenVanDeEredienst/6fdd5f4db430e5bc42d4e1fb130d6eb2 -> EB without CB
- You can check the Centrale Bestuur status with `regorg:orgStatus`
	- <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> Niet actief
	- <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> actief

E.g if you are looking for an active one : 

```sparql
 PREFIX regorg: <http://www.w3.org/ns/regorg#>
 PREFIX org: <http://www.w3.org/ns/org#>
 PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>

 SELECT DISTINCT ?centraleBestuur ?status ?eredienstBestuur WHERE {
	   BIND(<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> AS ?status)
     ?centraleBestuur a ere:CentraalBestuurVanDeEredienst ;
                        regorg:orgStatus ?status;
                        org:hasSubOrganization ?eredienstBestuur .
        } LIMIT 10
```

You can play around to find the rules if you need. Once submissions are ingested you can change the status of the CB

```sparql
PREFIX regorg: <http://www.w3.org/ns/regorg#>
INSERT {
GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
<http://data.lblod.info/id/centraleBesturenVanDeEredienst/be81b3003bfe0188c8f3bc21ef031bcc> regorg:orgStatus <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>
}
}

DELETE {
GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
<http://data.lblod.info/id/centraleBesturenVanDeEredienst/be81b3003bfe0188c8f3bc21ef031bcc> regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>
}
}

WHERE {
GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
<http://data.lblod.info/id/centraleBesturenVanDeEredienst/be81b3003bfe0188c8f3bc21ef031bcc> regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>
}
}
```

Then run the healing from the day of creation of your submissions e.g : 
`docker-compose exec submissions-dispatcher wget http://localhost/heal-submission?sentDateSince=2024-03-01`

Note that there is many edge cases like EB has no CB, then it's linked to the RO but in some cases there is no RO, so the GO or PO should be the ones that receive the submissions once dispatched

#### Test case 

##### Dispatched to CKB Diest as Actief 
![Screenshot 2024-03-12 at 17-13-46 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/2a25c507-da7e-4edc-8aee-38c0bba5a5fc)


##### Healed after making CKB Diest as Niet actief
![Screenshot 2024-03-12 at 17-31-33 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/b44919e5-2663-4b4f-9d27-30d42d8f8ea1)

Re-dispatched 
Jaarrekening case -> Sender / GO or PO / PG (ABB)
Budget(wijziging) -> Sender / PG (ABB) / RO if there is a RO, if not, to the GO or PO
Meerjarenplan(aanpasing) -> Sender / PG (ABB) / RO (assuming there is a RO) / GO or PO

![Screenshot 2024-03-12 at 17-37-10 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/2a9c4712-67c6-43df-9897-f5cdb9c3316b)

![Screenshot 2024-03-12 at 18-36-45 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/5bd3e5f3-3137-4d7d-ad67-c5b159e242a9)

![Screenshot 2024-03-12 at 18-37-08 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/f799d3a3-c663-4cb2-943e-e980d23cce0c)

![Screenshot 2024-03-12 at 18-37-38 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/de8a66a6-e95b-4e97-942d-4ec873618d68)

 
# What to check

- N/A

# Links to other PR's

- N/A

# Notes

Bump release version when tested + update changelog