### PR TITLE
Fix/consumer deletes statements

### DIFF
--- a/config/op-consumer/public/delta-sync-dispatching.js
+++ b/config/op-consumer/public/delta-sync-dispatching.js
@@ -1,5 +1,6 @@
 const {
   transformStatements,
+  removeContextTriples,
   deleteFromTargetGraph,
   insertIntoTargetGraph,
 } = require('./util');
@@ -64,30 +65,39 @@ async function dispatch(lib, data) {
     if (originalDeletes.length) {
       // Map deletes from OP to DL model
       const transformedDeletes = await transformStatements(fetch, deletesWithContext);
+      const filteredDeletes = removeContextTriples(transformedDeletes, originalDeletes, deletesWithContext);
 
-      if (!transformedDeletes.length) {
+      if (!filteredDeletes.length) {
         console.log(`Warn: Delete statements mapped to empty result.`);
         console.log(`Input: ${deletesWithContext}`);
-        console.log(`Output: ${transformedDeletes}`);
+        console.log(`Output: ${filteredDeletes}`);
       } else {
-        await deleteFromTargetGraph(lib, transformedDeletes);
+        await deleteFromTargetGraph(lib, filteredDeletes);
       }
     }
 
     if (originalInserts.length) {
       // Map inserts from OP to DL model
       const transformedInserts = await transformStatements(fetch, insertsWithContext);
+      const filteredInserts = removeContextTriples(transformedInserts, originalInserts, insertsWithContext);
 
-      if (!transformedInserts.length) {
+      if (!filteredInserts.length) {
         console.log(`Warn: Insert statements mapped to empty result.`);
         console.log(`Input: ${insertsWithContext}`);
-        console.log(`Output: ${transformedInserts}`);
+        console.log(`Output: ${filteredInserts}`);
       } else {
-        await insertIntoTargetGraph(lib, transformedInserts);
+        await insertIntoTargetGraph(lib, filteredInserts);
       }
     }
   }
 }
+
+// Function to serialize object for comparison
+function serializeTriple({ graph, subject, predicate, object }) {
+  return `${graph}|${subject}|${predicate}|${object}`;
+}
+
+
 
 module.exports = {
   dispatch

--- a/config/op-consumer/public/delta-sync-dispatching.js
+++ b/config/op-consumer/public/delta-sync-dispatching.js
@@ -92,12 +92,6 @@ async function dispatch(lib, data) {
   }
 }
 
-// Function to serialize object for comparison
-function serializeTriple({ graph, subject, predicate, object }) {
-  return `${graph}|${subject}|${predicate}|${object}`;
-}
-
-
 
 module.exports = {
   dispatch

--- a/config/op-consumer/public/util.js
+++ b/config/op-consumer/public/util.js
@@ -27,6 +27,8 @@ async function batchedDbUpdate(muUpdate,
   for (let i = 0; i < triples.length; i += batchSize) {
     console.log(`Inserting triples in batch: ${i}-${i + batchSize}`);
 
+    console.log(`Sending ${operation} query to ${endpoint} with ${batchSize} triples`);
+
     const batch = triples.slice(i, i + batchSize).join('\n');
 
     const insertCall = async () => {
@@ -105,21 +107,26 @@ function transformTriples(fetch, triples) {
  */
 function removeContextTriples(transformedTriples, originalTriples, triplesWithContext) {
   // Create sets for faster lookup
-  const originalSet = new Set(originalTriples.map(serializeTriple));
-  const contextSet = new Set(triplesWithContext.map(serializeTriple));
+  const originalSet = new Set(originalTriples);
+  const contextSet = new Set(triplesWithContext);
+
+  // console.log(`*****************************************************`)
+  // console.log(`**             removeContextTriples                **`)
+  // console.log(`*****************************************************`)
+  // console.log(`Original set: ${originalSet.size}, Context set: ${contextSet.size}`);
+  // console.log(`Original triples: ${originalTriples.length}, Context triples: ${triplesWithContext.length}, Transformed triples: ${transformedTriples.length}`);
+  // console.log(`Original triples: ${JSON.stringify(originalTriples)}`);
+  // console.log(`Context triples: ${JSON.stringify(triplesWithContext)}`);
+  // console.log(`Transformed triples: ${JSON.stringify(transformedTriples)}`);
 
   // Filter transformedTriples based on condition
-  const result = transformedTriples.filter(item => {
-    const serializedItem = serializeTriple(item);
-    const isInContextNotInOriginal = contextSet.has(serializedItem) && !originalSet.has(serializedItem);
+  return transformedTriples.filter(item => {
+    const isInContextNotInOriginal = contextSet.has(item) && !originalSet.has(item);
+    // console.log(`Item: ${item}, isInContextNotInOriginal: ${isInContextNotInOriginal}`);
     return !isInContextNotInOriginal; // Keep the item if it does not satisfy the removal condition
   });
 }
 
-// Function to serialize object for comparison
-function serializeTriple({ graph, subject, predicate, object }) {
-  return `${subject}|${predicate}|${object}`;
-}
 
 function mainConversion(fetch, triples) {
   let formdata = new URLSearchParams();


### PR DESCRIPTION
Reduce delete statements in the op delta consumer.
Instead of inserting/deleting the whole transformed result, now the triples which were added as context are filtered out before instering/deleting.