### PR TITLE
Vendor API data mappings

### DIFF
--- a/config/vendor-data/subjectsAndPaths.js
+++ b/config/vendor-data/subjectsAndPaths.js
@@ -100,6 +100,7 @@ export const subjects = [
         OPTIONAL {
           ?formdata <http://purl.org/dc/terms/hasPart> ?remotefile .
           ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?originalDownloadLink .
+          FILTER (!REGEX(STR(?originalDownloadLink), "${HOSTNAME}files/"))
           ?remotefile <http://mu.semte.ch/vocabularies/core/uuid> ?remotefileUUID .
           BIND (CONCAT("${HOSTNAME}files/", STR(?remotefileUUID), "/download") AS ?newDownloadLink)
         }
@@ -195,6 +196,7 @@ export const subjects = [
         OPTIONAL {
           ?subject <http://purl.org/dc/terms/hasPart> ?remotefile .
           ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?originalDownloadLink .
+          FILTER (!REGEX(STR(?originalDownloadLink), "${HOSTNAME}files/"))
           ?remotefile <http://mu.semte.ch/vocabularies/core/uuid> ?remotefileUUID .
           BIND (CONCAT("${HOSTNAME}files/", STR(?remotefileUUID), "/download") AS ?newDownloadLink)
         }
@@ -296,6 +298,7 @@ export const subjects = [
         OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/taxRateAmount> ?taxRateAmount . }
         OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/regulationType> ?regulationType . }
         ?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?originalDownloadLink .
+        FILTER (!REGEX(STR(?originalDownloadLink), "${HOSTNAME}files/"))
         ?subject <http://mu.semte.ch/vocabularies/core/uuid> ?remotefileUUID .
         BIND (CONCAT("${HOSTNAME}files/", STR(?remotefileUUID), "/download") AS ?newDownloadLink)
       `,

--- a/config/vendor-data/subjectsAndPaths.js
+++ b/config/vendor-data/subjectsAndPaths.js
@@ -29,12 +29,12 @@ export const subjects = [
     `,
     path: `
       GRAPH ?g {
-        ?subject a <http://rdf.myexperiment.org/ontologies/base/Submission>.
+        ?subject a <http://rdf.myexperiment.org/ontologies/base/Submission> .
       }
       FILTER (REGEX(STR(?g), "^http://mu.semte.ch/graphs/organizations/"))
       BIND(STRAFTER(STR(?g), "http://mu.semte.ch/graphs/organizations/") AS ?afterPrefix)
       BIND(STRBEFORE(?afterPrefix, "/LoketLB-databankEredienstenGebruiker") AS ?uuid)
-      ?organisation <http://mu.semte.ch/vocabularies/core/uuid> ?uuid.
+      ?organisation <http://mu.semte.ch/vocabularies/core/uuid> ?uuid .
     `,
     remove: {
       delete: `
@@ -94,12 +94,12 @@ export const subjects = [
       GRAPH ?g {
         ?submission
           a <http://rdf.myexperiment.org/ontologies/base/Submission> ;
-          <http://www.w3.org/ns/prov#generated> ?subject.
+          <http://www.w3.org/ns/prov#generated> ?subject .
       }
       FILTER (REGEX(STR(?g), "^http://mu.semte.ch/graphs/organizations/"))
       BIND(STRAFTER(STR(?g), "http://mu.semte.ch/graphs/organizations/") AS ?afterPrefix)
       BIND(STRBEFORE(?afterPrefix, "/LoketLB-databankEredienstenGebruiker") AS ?uuid)
-      ?organisation <http://mu.semte.ch/vocabularies/core/uuid> ?uuid.
+      ?organisation <http://mu.semte.ch/vocabularies/core/uuid> ?uuid .
     `,
     remove: {
       delete: `
@@ -163,7 +163,7 @@ export const subjects = [
       GRAPH ?g {
         ?submission
           a <http://rdf.myexperiment.org/ontologies/base/Submission> ;
-          <http://www.w3.org/ns/prov#generated> ?formdata.
+          <http://www.w3.org/ns/prov#generated> ?formdata .
         ?formdata
           a <http://lblod.data.gift/vocabularies/automatische-melding/FormData> ;
           <http://purl.org/dc/terms/hasPart> ?subject .
@@ -171,7 +171,7 @@ export const subjects = [
       FILTER (REGEX(STR(?g), "^http://mu.semte.ch/graphs/organizations/"))
       BIND(STRAFTER(STR(?g), "http://mu.semte.ch/graphs/organizations/") AS ?afterPrefix)
       BIND(STRBEFORE(?afterPrefix, "/LoketLB-databankEredienstenGebruiker") AS ?uuid)
-      ?organisation <http://mu.semte.ch/vocabularies/core/uuid> ?uuid.
+      ?organisation <http://mu.semte.ch/vocabularies/core/uuid> ?uuid .
     `,
     remove: {
       delete: `

--- a/config/vendor-data/subjectsAndPaths.js
+++ b/config/vendor-data/subjectsAndPaths.js
@@ -59,7 +59,6 @@ export const subjects = [
         ?subject ?sp ?so .
         ?formdata ?fp ?fo .
         ?remotefile ?ro ?rp .
-        ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?remotefileDownloadLink .
       `,
       where: `
         {
@@ -69,9 +68,40 @@ export const subjects = [
         } UNION {
           ?subject <http://www.w3.org/ns/prov#generated> ?formdata .
           ?formdata <http://purl.org/dc/terms/hasPart> ?remotefile .
-          ?remotefile <http://mu.semte.ch/vocabularies/core/uuid> ?remotefileUUID .
-          BIND (CONCAT("${HOSTNAME}files/", STR(?remotefileUUID), "/download") AS ?remotefileDownloadLink)
           ?remotefile ?ro ?rp .
+        }
+      `,
+    },
+    post: {
+      delete: `
+        ?formdata <http://mu.semte.ch/vocabularies/ext/sessionStartedAtTime> ?sessionStartedAtTime .
+        ?formdata <http://mu.semte.ch/vocabularies/ext/decisionType> ?decisionType .
+        ?formdata <http://mu.semte.ch/vocabularies/ext/taxType> ?taxType .
+        ?formdata <http://mu.semte.ch/vocabularies/ext/taxRateAmount> ?taxRateAmount .
+        ?formdata <http://mu.semte.ch/vocabularies/ext/regulationType> ?regulationType .
+        ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?originalDownloadLink .
+      `,
+      insert: `
+        ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/sessionStartedAtTime> ?sessionStartedAtTime .
+        ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/submissionType> ?decisionType .
+        ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/taxType> ?taxType .
+        ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/taxRateAmount> ?taxRateAmount .
+        ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/regulationType> ?regulationType .
+        ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?newDownloadLink .
+        ?remotefile <https://www.w3.org/TR/prov-o/#hadPrimarySource> ?originalDownloadLink .
+      `,
+      where: `
+        ?subject <http://www.w3.org/ns/prov#generated> ?formdata .
+        OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/sessionStartedAtTime> ?sessionStartedAtTime . }
+        OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/decisionType> ?decisionType . }
+        OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/taxType> ?taxType . }
+        OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/taxRateAmount> ?taxRateAmount . }
+        OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/regulationType> ?regulationType . }
+        OPTIONAL {
+          ?formdata <http://purl.org/dc/terms/hasPart> ?remotefile .
+          ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?originalDownloadLink .
+          ?remotefile <http://mu.semte.ch/vocabularies/core/uuid> ?remotefileUUID .
+          BIND (CONCAT("${HOSTNAME}files/", STR(?remotefileUUID), "/download") AS ?newDownloadLink)
         }
       `,
     },
@@ -124,7 +154,6 @@ export const subjects = [
         ?submission ?sp ?so .
         ?subject ?fp ?fo .
         ?remotefile ?ro ?rp .
-        ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?remotefileDownloadLink .
       `,
       where: `
         {
@@ -134,9 +163,40 @@ export const subjects = [
         } UNION {
           ?submission <http://www.w3.org/ns/prov#generated> ?subject .
           ?subject <http://purl.org/dc/terms/hasPart> ?remotefile .
-          ?remotefile <http://mu.semte.ch/vocabularies/core/uuid> ?remotefileUUID .
-          BIND (CONCAT("${HOSTNAME}files/", STR(?remotefileUUID), "/download") AS ?remotefileDownloadLink)
           ?remotefile ?ro ?rp .
+        }
+      `,
+    },
+    post: {
+      delete: `
+        ?subject <http://mu.semte.ch/vocabularies/ext/sessionStartedAtTime> ?sessionStartedAtTime .
+        ?subject <http://mu.semte.ch/vocabularies/ext/decisionType> ?decisionType .
+        ?subject <http://mu.semte.ch/vocabularies/ext/taxType> ?taxType .
+        ?subject <http://mu.semte.ch/vocabularies/ext/taxRateAmount> ?taxRateAmount .
+        ?subject <http://mu.semte.ch/vocabularies/ext/regulationType> ?regulationType .
+        ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?originalDownloadLink .
+      `,
+      insert: `
+        ?subject <http://lblod.data.gift/vocabularies/besluit/submission/form-data/sessionStartedAtTime> ?sessionStartedAtTime .
+        ?subject <http://lblod.data.gift/vocabularies/besluit/submission/form-data/submissionType> ?decisionType .
+        ?subject <http://lblod.data.gift/vocabularies/besluit/submission/form-data/taxType> ?taxType .
+        ?subject <http://lblod.data.gift/vocabularies/besluit/submission/form-data/taxRateAmount> ?taxRateAmount .
+        ?subject <http://lblod.data.gift/vocabularies/besluit/submission/form-data/regulationType> ?regulationType .
+        ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?newDownloadLink .
+        ?remotefile <https://www.w3.org/TR/prov-o/#hadPrimarySource> ?originalDownloadLink .
+      `,
+      where: `
+        ?submission <http://www.w3.org/ns/prov#generated> ?subject .
+        OPTIONAL { ?subject <http://mu.semte.ch/vocabularies/ext/sessionStartedAtTime> ?sessionStartedAtTime . }
+        OPTIONAL { ?subject <http://mu.semte.ch/vocabularies/ext/decisionType> ?decisionType . }
+        OPTIONAL { ?subject <http://mu.semte.ch/vocabularies/ext/taxType> ?taxType . }
+        OPTIONAL { ?subject <http://mu.semte.ch/vocabularies/ext/taxRateAmount> ?taxRateAmount . }
+        OPTIONAL { ?subject <http://mu.semte.ch/vocabularies/ext/regulationType> ?regulationType . }
+        OPTIONAL {
+          ?subject <http://purl.org/dc/terms/hasPart> ?remotefile .
+          ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?originalDownloadLink .
+          ?remotefile <http://mu.semte.ch/vocabularies/core/uuid> ?remotefileUUID .
+          BIND (CONCAT("${HOSTNAME}files/", STR(?remotefileUUID), "/download") AS ?newDownloadLink)
         }
       `,
     },
@@ -196,7 +256,6 @@ export const subjects = [
         ?submission ?sp ?so .
         ?formdata ?fp ?fo .
         ?subject ?ro ?rp .
-        ?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?remotefileDownloadLink .
       `,
       where: `
         {
@@ -206,10 +265,39 @@ export const subjects = [
         } UNION {
           ?submission <http://www.w3.org/ns/prov#generated> ?formdata .
           ?formdata <http://purl.org/dc/terms/hasPart> ?subject .
-          ?subject <http://mu.semte.ch/vocabularies/core/uuid> ?subjectUUID .
-          BIND (CONCAT("${HOSTNAME}files/", STR(?subjectUUID), "/download") AS ?remotefileDownloadLink)
           ?subject ?ro ?rp .
         }
+      `,
+    },
+    post: {
+      delete: `
+        ?formdata <http://mu.semte.ch/vocabularies/ext/sessionStartedAtTime> ?sessionStartedAtTime .
+        ?formdata <http://mu.semte.ch/vocabularies/ext/decisionType> ?decisionType .
+        ?formdata <http://mu.semte.ch/vocabularies/ext/taxType> ?taxType .
+        ?formdata <http://mu.semte.ch/vocabularies/ext/taxRateAmount> ?taxRateAmount .
+        ?formdata <http://mu.semte.ch/vocabularies/ext/regulationType> ?regulationType .
+        ?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?originalDownloadLink .
+      `,
+      insert: `
+        ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/sessionStartedAtTime> ?sessionStartedAtTime .
+        ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/submissionType> ?decisionType .
+        ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/taxType> ?taxType .
+        ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/taxRateAmount> ?taxRateAmount .
+        ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/regulationType> ?regulationType .
+        ?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?newDownloadLink .
+        ?subject <https://www.w3.org/TR/prov-o/#hadPrimarySource> ?originalDownloadLink .
+      `,
+      where: `
+        ?submission <http://www.w3.org/ns/prov#generated> ?formdata .
+        ?formdata <http://purl.org/dc/terms/hasPart> ?subject .
+        OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/sessionStartedAtTime> ?sessionStartedAtTime . }
+        OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/decisionType> ?decisionType . }
+        OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/taxType> ?taxType . }
+        OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/taxRateAmount> ?taxRateAmount . }
+        OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/regulationType> ?regulationType . }
+        ?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?originalDownloadLink .
+        ?subject <http://mu.semte.ch/vocabularies/core/uuid> ?remotefileUUID .
+        BIND (CONCAT("${HOSTNAME}files/", STR(?remotefileUUID), "/download") AS ?newDownloadLink)
       `,
     },
   },

--- a/config/vendor-data/subjectsAndPaths.js
+++ b/config/vendor-data/subjectsAndPaths.js
@@ -100,7 +100,6 @@ export const subjects = [
         OPTIONAL {
           ?formdata <http://purl.org/dc/terms/hasPart> ?remotefile .
           ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?originalDownloadLink .
-          FILTER (!REGEX(STR(?originalDownloadLink), "${HOSTNAME}files/"))
           ?remotefile <http://mu.semte.ch/vocabularies/core/uuid> ?remotefileUUID .
           BIND (CONCAT("${HOSTNAME}files/", STR(?remotefileUUID), "/download") AS ?newDownloadLink)
         }
@@ -196,7 +195,6 @@ export const subjects = [
         OPTIONAL {
           ?subject <http://purl.org/dc/terms/hasPart> ?remotefile .
           ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?originalDownloadLink .
-          FILTER (!REGEX(STR(?originalDownloadLink), "${HOSTNAME}files/"))
           ?remotefile <http://mu.semte.ch/vocabularies/core/uuid> ?remotefileUUID .
           BIND (CONCAT("${HOSTNAME}files/", STR(?remotefileUUID), "/download") AS ?newDownloadLink)
         }
@@ -298,7 +296,6 @@ export const subjects = [
         OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/taxRateAmount> ?taxRateAmount . }
         OPTIONAL { ?formdata <http://mu.semte.ch/vocabularies/ext/regulationType> ?regulationType . }
         ?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?originalDownloadLink .
-        FILTER (!REGEX(STR(?originalDownloadLink), "${HOSTNAME}files/"))
         ?subject <http://mu.semte.ch/vocabularies/core/uuid> ?remotefileUUID .
         BIND (CONCAT("${HOSTNAME}files/", STR(?remotefileUUID), "/download") AS ?newDownloadLink)
       `,

--- a/config/vendor-data/subjectsAndPaths.js
+++ b/config/vendor-data/subjectsAndPaths.js
@@ -88,7 +88,7 @@ export const subjects = [
         ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/taxRateAmount> ?taxRateAmount .
         ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/regulationType> ?regulationType .
         ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?newDownloadLink .
-        ?remotefile <https://www.w3.org/TR/prov-o/#hadPrimarySource> ?originalDownloadLink .
+        ?remotefile <http://www.w3.org/ns/prov#hadPrimarySource> ?originalDownloadLink .
       `,
       where: `
         ?subject <http://www.w3.org/ns/prov#generated> ?formdata .
@@ -183,7 +183,7 @@ export const subjects = [
         ?subject <http://lblod.data.gift/vocabularies/besluit/submission/form-data/taxRateAmount> ?taxRateAmount .
         ?subject <http://lblod.data.gift/vocabularies/besluit/submission/form-data/regulationType> ?regulationType .
         ?remotefile <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?newDownloadLink .
-        ?remotefile <https://www.w3.org/TR/prov-o/#hadPrimarySource> ?originalDownloadLink .
+        ?remotefile <http://www.w3.org/ns/prov#hadPrimarySource> ?originalDownloadLink .
       `,
       where: `
         ?submission <http://www.w3.org/ns/prov#generated> ?subject .
@@ -285,7 +285,7 @@ export const subjects = [
         ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/taxRateAmount> ?taxRateAmount .
         ?formdata <http://lblod.data.gift/vocabularies/besluit/submission/form-data/regulationType> ?regulationType .
         ?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?newDownloadLink .
-        ?subject <https://www.w3.org/TR/prov-o/#hadPrimarySource> ?originalDownloadLink .
+        ?subject <http://www.w3.org/ns/prov#hadPrimarySource> ?originalDownloadLink .
       `,
       where: `
         ?submission <http://www.w3.org/ns/prov#generated> ?formdata .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -307,7 +307,7 @@ services:
     restart: always
     logging: *default-logging
   vendor-data-distribution:
-    image: lblod/vendor-data-distribution-service:1.4.1
+    image: lblod/vendor-data-distribution-service:1.5.0
     environment:
       LOGLEVEL: "error"
       WRITE_ERRORS: "true"


### PR DESCRIPTION
Some predicates needed to be renamed and the download link needed to use a different predicate.

For this, the new post processing feature of the VDDS can be used. This adds a new configuration property where you can execute a `DELETE {...} INSERT {...} WHERE {...}` query an the subject that was just inserted in the vendor graph.