### PR TITLE
VDDS configure mu-scope

### DIFF
--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -11,8 +11,10 @@ export default [
       resourceFormat: "v0.0.1",
       gracePeriod: 1000,
       ignoreFromSelf: true,
-      optOutMuScopeIds: [ "http://redpencil.data.gift/id/concept/muScope/deltas/consumer/initialSync",
-                          "http://redpencil.data.gift/id/concept/muScope/deltas/write-for-dispatch" ]
+      optOutMuScopeIds: [
+        "http://redpencil.data.gift/id/concept/muScope/deltas/consumer/initialSync",
+        "http://redpencil.data.gift/id/concept/muScope/deltas/write-for-dispatch",
+      ],
     }
   },
   {

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -14,6 +14,7 @@ export default [
       optOutMuScopeIds: [
         "http://redpencil.data.gift/id/concept/muScope/deltas/consumer/initialSync",
         "http://redpencil.data.gift/id/concept/muScope/deltas/write-for-dispatch",
+        "http://redpencil.data.gift/id/concept/muScope/deltas/vendor-data",
       ],
     }
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     restart: always
     logging: *default-logging
   deltanotifier:
-    image: semtech/mu-delta-notifier:0.2.0
+    image: cecemel/delta-notifier:0.2.0-beta.6
     volumes:
       - ./config/delta:/config
     labels:
@@ -101,7 +101,7 @@ services:
     restart: always
     logging: *default-logging
   database:
-    image: semtech/mu-authorization:0.6.0-beta.8
+    image: semtech/mu-authorization:feature-service-roam-r1.1
     environment:
       MU_SPARQL_ENDPOINT: "http://virtuoso:8890/sparql"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -307,7 +307,7 @@ services:
     restart: always
     logging: *default-logging
   vendor-data-distribution:
-    image: lblod/vendor-data-distribution-service:1.5.0
+    image: lblod/vendor-data-distribution-service:1.6.0
     environment:
       LOGLEVEL: "error"
       WRITE_ERRORS: "true"


### PR DESCRIPTION
With version v1.6.0 of the VDDS ([see its PR](https://github.com/lblod/vendor-data-distribution-service/pull/15)), we can use the `mu-call-scope-id` to opt-out of delta messages to `mu-cl-resources` to prevent it from being overloaded.

**How to test**

Before checking out this branch, inspect the logs of `mu-cl-resource` and run a healing on the VDDS. Notice the many logs `mu-cl-resources` generates as it is trying to keep up with the changes.

Then checkout this branch and perform the healing again. There should be no logs, because the data generated comes from the VDDS and should be within the mu-scope that is ignored by the `delta-notifier`.