### PR TITLE
Bump worship submissions email notification service to v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Unreleased (2024-MM-DD)
 - Add `vendor-management-consumer` to fetch vendor data from `app-digitaal-loket` (DL-5667)
 - Add `vendor-data-distribution` and config to copy data to vendor graphs based on config
+- Bump `worship-submissions-email-notification-service` to `v1.2.0` (DL-5742)
+  - See full change [here](https://github.com/lblod/worship-submissions-email-notification-service/pull/3)
 ### Deploy Notes
 #### `vendor-management-consumer` Setup
 Place the following inside `docker-compose.override.yml`:
@@ -37,7 +39,7 @@ drc exec vendor-data-distribution curl -X POST -H "Content-Type: application/jso
 **This can take up multiple hours of high triplestore usage! Perform outside of peak hours.**
 
 #### Docker Commands
-- `drc up -d vendor-management-consumer submissions-dispatcher`
+- `drc up -d vendor-management-consumer submissions-dispatcher worship-submissions-email-notification-service`
 - `drc logs -ft --tail=200 vendor-management-consumer`
   - > Make sure the logs contain no issues.
 - Switch `DCR_DISABLE_INITIAL_SYNC` inside `vendor-management-consumer` to `false`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -287,7 +287,7 @@ services:
     restart: always
     logging: *default-logging
   worship-submissions-email-notification-service:
-    image: lblod/worship-submissions-email-notification-service:1.1.0
+    image: lblod/worship-submissions-email-notification-service:1.2.0
     environment:
       RUN_INTERVAL: "0 10 * * *"
       OUTBOX_FOLDER_URI: "http://data.lblod.info/id/mail-folders/2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,8 +293,8 @@ services:
       OUTBOX_FOLDER_URI: "http://data.lblod.info/id/mail-folders/2"
       FROM_EMAIL_ADDRESS: "Agentschap Binnenlands Bestuur Vlaanderen <noreply-binnenland@vlaanderen.be>"
       WORSHIP_DECISIONS_APP_BASEURL: "https://databankerediensten.lokaalbestuur.vlaanderen.be/"
-      restart: always
-      logging: *default-logging
+    restart: always
+    logging: *default-logging
   ##############################################################################
   # Vendor API
   ##############################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,7 +291,7 @@ services:
     environment:
       RUN_INTERVAL: "0 10 * * *"
       OUTBOX_FOLDER_URI: "http://data.lblod.info/id/mail-folders/2"
-      FROM_EMAIL_ADRESS: "Agentschap Binnenlands Bestuur Vlaanderen <noreply-binnenland@vlaanderen.be>"
+      FROM_EMAIL_ADDRESS: "Agentschap Binnenlands Bestuur Vlaanderen <noreply-binnenland@vlaanderen.be>"
       WORSHIP_DECISIONS_APP_BASEURL: "https://databankerediensten.lokaalbestuur.vlaanderen.be/"
   ##############################################################################
   # Vendor API

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,6 +293,8 @@ services:
       OUTBOX_FOLDER_URI: "http://data.lblod.info/id/mail-folders/2"
       FROM_EMAIL_ADDRESS: "Agentschap Binnenlands Bestuur Vlaanderen <noreply-binnenland@vlaanderen.be>"
       WORSHIP_DECISIONS_APP_BASEURL: "https://databankerediensten.lokaalbestuur.vlaanderen.be/"
+      restart: always
+      logging: *default-logging
   ##############################################################################
   # Vendor API
   ##############################################################################


### PR DESCRIPTION
# Description
DL-5742 -> DL-5715

This PR fixes some issues with the service, updating dependencies along with adding more information about submissions in the email template. 

- Updating dependencies
- Adding date-fns and date-fns-tz packages
- Adjusting query variable `?submission` in favor of `?submissionUri`
- Updating mock-email accordingly with the new formatted data payload			
- Adding formatted url directly into the submission object from each submissions with the function  `addUrlPerSubmission(submissionUri)` previously named `getLinks()` https://github.com/lblod/worship-submissions-email-notification-service/pull/3/files#diff-80b0520dd0dbcf7162aba6a748e053a5ab7d2f96603a96e60fc710249f535dbfL133
- Improving conditional check, submissions wont be appended twice and if submissions made by `creatorEenheidLabel` = `targetEenheidLabel`, they wont be added to the bundle
- Adjusting HTML template
  - Adding style to include a table
  - Injecting table rows with each submissions information such as `sentDate`, `decisionTypeLabel`, `creatorEenheidLabel` and `url`
  - Submissions ordered by DESC

## Template preview v1.2.0-rc.1
![Screenshot 2024-04-02 at 16-07-17 Screenshot](https://github.com/lblod/worship-submissions-email-notification-service/assets/38471754/d9040352-f282-4ab8-9376-75474f7bd0f4)

## Template preview with v1.2.0-rc.2
![Screenshot 2024-04-15 at 12-07-00 Screenshot](https://github.com/lblod/app-worship-decisions-database/assets/38471754/5721c110-852c-4d62-9913-9fc6a33749e3)


# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related stack

- https://github.com/lblod/app-worship-decisions-database

# How to test 

1. Run the worship-decisions-database stack with the new image. Add a config if you didn't, see https://github.com/lblod/worship-submissions-email-notification-service?tab=readme-ov-file#-quick-setup
2. Subscribe to notifications 
![Screenshot 2023-09-18 at 17-17-13 Erediensten Toezichtsdatabank-inzending](https://github.com/lblod/worship-submissions-email-notification-service/assets/38471754/13bd5cc5-4e75-4d1f-befb-2491a4ac9771)
3. Log the service, it should bundle notifications to be sent. Few rules are executed.
3.1. Submissions sent by the target (subscribed administrative unit) wont be sent as notification
3.2. Submissions shouldn't be duplicated in the notifications, you should end up with this message after the process is done `Placing ${targetEenheidLabel}'s email notification ${email.uri} into outbox` as reminder outbox = `<http://data.lblod.info/id/mail-folders/2>`
3.3. Note that you can also use routes `/mock-insert-single` and `/mock-insert-multiple` to test, see how to in https://github.com/lblod/worship-submissions-email-notification-service?tab=readme-ov-file#-testing
4. Log `deliver-email-service | grep 'Preview' ` it should return an URL to preview the email locally meaning that email is processed and delivered in sentbox.

# What to check

- N/A

# Links to other PR's

- N/A

# Notes

drc up -d worship-submission-email-notification-service