### PR TITLE
Add missing HOSTNAME env var in compose dev file

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,4 +63,6 @@ services:
   sparql-authorization-wrapper:
     restart: "no"
   vendor-data-distribution:
+    environment:
+      HOSTNAME: "http://localhost"
     restart: "no"


### PR DESCRIPTION
## Description

`vendor-data-distribution` needs the `HOSTNAME` environment variable in order to assign download links for the files inside the vendor graph; however, this variable is missing in our local development environment.