### PR TITLE
Add vendor API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,119 @@ drc up -d
   * make the `scripts/project/build-elasticsearch-config/build.sh` executable (`chmod a+x`)
   * make sure the virtuoso image is running
   * run `mu script project-scripts build-elasticsearch-config`
+
+## Vendor API
+
+Some vendors need access to specific data inside Loket; as such, we expose an API that allows them to query data from their own designated graphs.
+
+There are three services involved:
+* [vendor-login-service](https://github.com/lblod/vendor-login-service)
+* [sparql-authorization-wrapper-service](https://github.com/lblod/sparql-authorization-wrapper-service)
+* [vendor-data-distribution-service](https://github.com/lblod/vendor-data-distribution-service/)
+
+In brief, the API flows as follows:
+* The `vendor-login` service allows a vendor with an API key to log into `app-digitaal-loket` and provides said vendor with an active session.
+* The `sparql-authorization-wrapper` service proxies SPARQL requests from the vendor to `app-digitaal-loket` by intercepting the request and adding specific authorization rules to allow/disallow this request; these rules are defined in `config/sparql-authorization-wrapper/filter.js`.
+  * `sparql-authorization-wrapper` checks whether a vendor has an active session by querying the sessions created by `vendor-login`.
+* The `vendor-data-distribution` service copies data inside `app-digitaal-loket` to designated graphs, which are made accessible through the SPARQL endpoint; the rules defining what gets copied are defined in `config/vendor-data/subjectsAndPaths.js`.
+
+### Usage
+
+#### vendor-login-service
+
+To log in as a vendor, run the following command:
+
+```sh
+curl -v -X POST \
+      -H "Content-Type: application/json" \
+      -b CookieJar.tsv -c CookieJar.tsv \
+      -d '{
+    "organization": "ORG_URI",
+    "publisher": {
+        "uri": "VENDOR_URI",
+        "key": "VENDOR_API_KEY"
+    }
+}' http://localhost:90/vendor/login
+```
+
+where:
+* `ORG_URI` is the URI of the organization the vendor can act on behalf of.
+* `VENDOR_URI` is the URI of the relevant vendor.
+* `VENDOR_API_KEY` is the API key the vendor uses to log in.
+
+`VENDOR_URI`, `VENDOR_API_KEY` and `ORG_URI` can be found by querying the database as follows:
+
+```sparql
+PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+PREFIX mu:        <http://mu.semte.ch/vocabularies/core/>
+PREFIX foaf:      <http://xmlns.com/foaf/0.1/>
+PREFIX ext:       <http://mu.semte.ch/vocabularies/ext/>
+
+SELECT DISTINCT ?vendorURI ?vendorName ?vendorAPIKey ?organizationURI WHERE {
+  ?s a foaf:Agent, ext:Vendor ;
+    muAccount:key ?key ;
+    muAccount:canActOnBehalfOf ?organizationURI ;
+    foaf:name ?vendorName .
+}
+```
+
+This query will return the **vendorURI**, **vendorName**, **vendorAPIKey** and **organizationURI**; **vendorName** is not used in the cURL request but is useful information to have.
+
+#### sparql-authorization-wrapper-service
+
+As mentioned in the summary above, this service acts as a proxy between the vendor and `app-digitaal-loket` and is used to append extra authorization rules in addition to making sure the client is allowed to access the requested data.
+
+After logging in as a vendor, run the following command to execute a query (note the use of the same `CookieJar.tsv` from the previous section):
+
+```sh
+curl -s -X POST \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -b CookieJar.tsv -c CookieJar.tsv \
+  --data-urlencode 'query=SELECT ?s ?p ?o WHERE { ?s a <http://rdf.myexperiment.org/ontologies/base/Submission> ; ?p ?o . }' \
+  --location "http://localhost:90/vendor/sparql" --write-out '%{json}' | jq '.results'
+```
+
+**NOTE**: The `--write-out '%{json}' | jq '.results'` snippet at the end allows for a nicer output, but it can be removed. You need to install `jq` first if you choose to write out the JSON output to `jq`.
+
+The following is an example output you may see after executing the request:
+
+```json
+{
+  "ordered": true,
+  "distinct": false,
+  "bindings": [
+    {
+      "s": {
+        "value": "http://data.lblod.info/submissions/79cecc4f-ad73-453a-9a22-406e5a88d092",
+        "type": "uri"
+      },
+      "p": {
+        "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "type": "uri"
+      },
+      "o": {
+        "value": "http://rdf.myexperiment.org/ontologies/base/Submission",
+        "type": "uri"
+      }
+    }
+  ]
+}
+```
+
+##### Service Configuration (filter.js)
+
+The custom authorization rules are defined in a custom [filter.js](https://github.com/lblod/app-worship-decisions-database/blob/master/config/sparql-authorization-wrapper/filter.js) file. You can write out the specific query you want executed inside the `isAuthorized()` function, and `sparql-authorization-wrapper-service` will use it when proxying requests from the vendor.
+
+More info can found in the [writing rules](https://github.com/lblod/sparql-authorization-wrapper-service?tab=readme-ov-file#writing-rules) section of the service's README page.
+
+#### vendor-data-distribution-service
+
+This service works by reacting to deltas and is responsible for moving vendor-relevant data into specific graphs, where they can then be accessed through the vendor API.
+
+##### Service Configuration (subjectsAndPaths.js)
+
+This service is configured through a custom [subjectsAndPaths.js](https://github.com/lblod/app-worship-decisions-database/blob/master/config/vendor-data/subjectsAndPaths.js) file, similar to `sparql-authorization-wrapper-service`. More info can be found [here](https://github.com/lblod/vendor-data-distribution-service/?tab=readme-ov-file#configuration).
+
+##### Healing Process
+
+The healing process allows the service to "manually" copy data to vendor graphs by the following the same rules defined in `subjectsAndPaths.js`. Trigger a `POST` request to the `/healing` endpoint of the service to start the healing.


### PR DESCRIPTION
## Ticket Number

DL-5794

## Ticket Description

With the vendor API having been integrated inside `app-worship-decisions-database`, we should document the API for anyone wanting to develop, use and/or test this API and the services encompassing it.

Given that this is more developer-facing documentation, I opted for small descriptions of the relevant services while linking any service-specific documentation back to the service's GitHub homepage as they are descriptive and informative enough.