### PR TITLE
[filter-form] Replace `Type bestuursorgaan` filter for `Type eredienst`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## Unreleased
+- frontend v0.12.0: https://github.com/lblod/frontend-worship-decisions/blob/master/CHANGELOG.md#0120-2024-06-19
+
+### Deploy notes
+- `drc up -d frontend search-query-management`
+- `drc restart resource cache`
+
 ## 0.26.1 (2024-05-29)
   - Fix custom info label field in forms LEKP-rapport - Melding correctie authentieke bron and LEKP-rapport - Toelichting Lokaal Bestuur (DL-5934)
 ### Deploy Notes

--- a/config/resources/repository.lisp
+++ b/config/resources/repository.lisp
@@ -30,6 +30,8 @@
 (add-prefix "toezichtReport" "http://mu.semte.ch/vocabularies/ext/supervision/reporting/")
 (add-prefix "nmo" "http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#")
 (add-prefix "lblodlg" "http://data.lblod.info/vocabularies/leidinggevenden/")
+(add-prefix "ere" "http://data.lblod.info/vocabularies/erediensten/")
+(add-prefix "code" "http://lblod.data.gift/vocabularies/organisatie/")
 
 (add-prefix "meb" "http://rdf.myexperiment.org/ontologies/base/")
 (add-prefix "melding" "http://lblod.data.gift/vocabularies/automatische-melding/")

--- a/config/resources/slave-besluit-domain.lisp
+++ b/config/resources/slave-besluit-domain.lisp
@@ -92,7 +92,9 @@
              (werkingsgebied :via ,(s-prefix "ext:inProvincie")
                              :as "provincie")
              (bestuurseenheid-classificatie-code :via ,(s-prefix "besluit:classificatie")
-                                                 :as "classificatie"))
+                                                 :as "classificatie")
+             (recognized-worship-type :via ,(s-prefix "ere:typeEredienst")
+                                      :as "recognized-worship-type"))
   :has-many `((contact-punt :via ,(s-prefix "schema:contactPoint")
                             :as "contactinfo")
               (bestuursorgaan :via ,(s-prefix "besluit:bestuurt")
@@ -101,6 +103,15 @@
   :resource-base (s-url "http://data.lblod.info/id/bestuurseenheden/")
   :features '(include-uri)
   :on-path "bestuurseenheden"
+)
+
+;; Defining the following resouce here for now as worship units have the type bestuurseenheid
+(define-resource recognized-worship-type ()
+  :class (s-prefix "code:TypeEredienst")
+  :properties `((:label :string ,(s-prefix "skos:prefLabel")))
+  :resource-base (s-url "http://lblod.data.gift/concepts/")
+  :features '(include-uri)
+  :on-path "recognized-worship-types"
 )
 
 (define-resource werkingsgebied ()

--- a/config/search-query/filter-form.ttl
+++ b/config/search-query/filter-form.ttl
@@ -144,7 +144,7 @@ fields:35465e1a-531a-4bab-8b19-bbd59f19cd4a a form:Field ;
     form:displayType displayTypes:conceptSchemeMultiSelector ;
     form:help "vb. Kerkfabriek of gemeente" ;
     sh:group fields:cb08e556-459d-4378-a79b-51f35c9a965e ;
-    form:hasConditionalFieldGroup fields:0fe2e436-673e-4cc8-9e29-f227f18dabb2. ## Governing Body Classification
+    form:hasConditionalFieldGroup fields:0fe2e436-673e-4cc8-9e29-f227f18dabb2. ## Type Eredienst
 
 fields:0fe2e436-673e-4cc8-9e29-f227f18dabb2 a form:ConditionalFieldGroup ;
     mu:uuid "0fe2e436-673e-4cc8-9e29-f227f18dabb2";
@@ -158,27 +158,27 @@ fields:0fe2e436-673e-4cc8-9e29-f227f18dabb2 a form:ConditionalFieldGroup ;
 fieldGroups:e982310c-1c90-43a6-bdd2-a1d15ad740aa a form:FieldGroup;
     mu:uuid "e982310c-1c90-43a6-bdd2-a1d15ad740aa" ;
     form:hasField
-                ### Governing Body Classification
+                ### Type Eredienst
                 fields:d18e810d-1ec8-4cdc-ac17-ee6b9d8958b6 .
 ##########################################################
 # END administrative unit classification
 ##########################################################
 
 ##########################################################
-# START governing body classification
+# START Type Eredienst
 ##########################################################
 fields:d18e810d-1ec8-4cdc-ac17-ee6b9d8958b6 a form:Field ;
     mu:uuid "d18e810d-1ec8-4cdc-ac17-ee6b9d8958b6" ;
-    sh:name "Type bestuursorgaan" ;
+    sh:name "Type eredienst" ;
     sh:order 80 ;
-    search:emberQueryParameterKey "governingBodyClassifications" ;
-    sh:path searchToezicht:governingBodyClassification ;
-    form:options  """{"conceptScheme":"http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode"}""" ;
+    search:emberQueryParameterKey "typeEredienst" ;
+    sh:path searchToezicht:typeEredienst ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/5be1fce008d73105d9bc6de9e488b0b9"}""" ;
     form:displayType displayTypes:conceptSchemeMultiSelector ;
-    form:help "vb. kerkraad of gemeenteraad" ;
+    form:help "vb. Anglicaanse, Islamitische, Israëlitische, Orthodox, Protestantse of Rooms-Katholiek" ;
     sh:group fields:cb08e556-459d-4378-a79b-51f35c9a965e .
 ##########################################################
-# END governing body classification
+# END Type Eredienst
 ##########################################################
 
 ##########################################################

--- a/config/search-query/filter-form.ttl
+++ b/config/search-query/filter-form.ttl
@@ -149,9 +149,14 @@ fields:35465e1a-531a-4bab-8b19-bbd59f19cd4a a form:Field ;
 fields:0fe2e436-673e-4cc8-9e29-f227f18dabb2 a form:ConditionalFieldGroup ;
     mu:uuid "0fe2e436-673e-4cc8-9e29-f227f18dabb2";
     form:conditions
-      [ a form:RequiredConstraint ;
+      [ a form:MatchValues ;
         form:grouping form:Bag ;
-        sh:path searchToezicht:administrativeUnitClassification
+        sh:path searchToezicht:administrativeUnitClassification ;
+        form:valuesIn (
+          <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> # Bestuur van de eredienst
+          <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> # Centraal bestuur van de eredienst
+          <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> # Representatief orgaan
+        ) ;
       ] ;
     form:hasFieldGroup fieldGroups:e982310c-1c90-43a6-bdd2-a1d15ad740aa .
 

--- a/config/search-query/filter-form.ttl
+++ b/config/search-query/filter-form.ttl
@@ -141,7 +141,7 @@ fields:35465e1a-531a-4bab-8b19-bbd59f19cd4a a form:Field ;
     search:emberQueryParameterKey "administrativeUnitClassifications" ;
     sh:path searchToezicht:administrativeUnitClassification ;
     form:options  """{"conceptScheme":"http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode"}""" ;
-    form:displayType displayTypes:conceptSchemeMultiSelector ;
+    form:displayType displayTypes:conceptSchemeSelector ;
     form:help "vb. Kerkfabriek of gemeente" ;
     sh:group fields:cb08e556-459d-4378-a79b-51f35c9a965e ;
     form:hasConditionalFieldGroup fields:0fe2e436-673e-4cc8-9e29-f227f18dabb2. ## Type Eredienst
@@ -174,7 +174,7 @@ fields:d18e810d-1ec8-4cdc-ac17-ee6b9d8958b6 a form:Field ;
     search:emberQueryParameterKey "typeEredienst" ;
     sh:path searchToezicht:typeEredienst ;
     form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/5be1fce008d73105d9bc6de9e488b0b9"}""" ;
-    form:displayType displayTypes:conceptSchemeMultiSelector ;
+    form:displayType displayTypes:conceptSchemeSelector ;
     form:help "vb. Anglicaanse, Islamitische, Israëlitische, Orthodox, Protestantse of Rooms-Katholiek" ;
     sh:group fields:cb08e556-459d-4378-a79b-51f35c9a965e .
 ##########################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
     restart: always
     logging: *default-logging
   search-query-management:
-    image: lblod/toezicht-search-query-management-service:0.3.6
+    image: lblod/toezicht-search-query-management-service:0.3.7-rc.1
     volumes:
       - ./config/search-query:/share/search-query
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
     restart: always
     logging: *default-logging
   search-query-management:
-    image: lblod/toezicht-search-query-management-service:0.3.7-rc.1
+    image: lblod/toezicht-search-query-management-service:feature-add-worship-types-concept-scheme
     volumes:
       - ./config/search-query:/share/search-query
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./scripts/project:/app/scripts/
     restart: "no"
   frontend:
-    image: lblod/frontend-worship-decisions:0.12.0-rc.1
+    image: lblod/frontend-worship-decisions:0.12.0
     volumes:
       - ./config/frontend:/config
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./scripts/project:/app/scripts/
     restart: "no"
   frontend:
-    image: lblod/frontend-worship-decisions:0.11.0
+    image: lblod/frontend-worship-decisions:0.12.0-rc.1
     volumes:
       - ./config/frontend:/config
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
     restart: always
     logging: *default-logging
   search-query-management:
-    image: lblod/toezicht-search-query-management-service:feature-add-worship-types-concept-scheme
+    image: lblod/toezicht-search-query-management-service:0.3.7
     volumes:
       - ./config/search-query:/share/search-query
     labels:


### PR DESCRIPTION
# Description
DL-5330

This PR replaces current filter `Type bestuursorgaan` filter for `Type eredienst` so users can look for recognized worship types when they're already filtering on `Type bestuur` leaving them 6 options to pick from _(Anglicaanse, Islamitische, Israëlitische, Orthodox, Protestantse of Rooms-Katholiek)_.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- [frontend-worship-decisions](https://github.com/lblod/frontend-worship-decisions)
- mu-cl-resource
- [toezicht-search-query-management](https://github.com/lblod/toezicht-search-query-management-service)

# How to test (From Loket app)

1. drc up -d 
2. Make sure the seach-query-management and frontend services have been pulled.
3. Log as ABB.
4. Apply type bestuur filter then type eredienst based on the 6 options.
5. It should show results.

**See Examples here**

![Screenshot 2024-06-10 at 18-04-26 Erediensten Toezichtsdatabank](https://github.com/lblod/app-worship-decisions-database/assets/38471754/3326c9c4-1098-43ff-9521-04a0c32e81bf)

![Screenshot 2024-06-10 at 18-04-47 Erediensten Toezichtsdatabank](https://github.com/lblod/app-worship-decisions-database/assets/38471754/f0aa0341-9ba3-45b5-be6c-e51443a3472c)



# What to check

- Typos 

# Links to other PR's

- https://github.com/lblod/toezicht-search-query-management-service/pull/1
- https://github.com/lblod/frontend-worship-decisions/pull/23

# Notes

- drc up -d frontend seach-query-management; drc restart resource cache + CHANGELOG 