### PR TITLE
Cross referencing `vendor-data-distribution-service` config

### DIFF
--- a/config/vendor-data/subjectsAndPaths.js
+++ b/config/vendor-data/subjectsAndPaths.js
@@ -45,8 +45,9 @@ export const subjects = [
       `,
       where: `
         {
-          ?subject <http://www.w3.org/ns/prov#generated> ?formdata .
           ?subject ?sp ?so .
+        } UNION {
+          ?subject <http://www.w3.org/ns/prov#generated> ?formdata .
           ?formdata ?fp ?fo .
         } UNION {
           ?subject <http://www.w3.org/ns/prov#generated> ?formdata .

--- a/config/vendor-data/subjectsAndPaths.js
+++ b/config/vendor-data/subjectsAndPaths.js
@@ -39,6 +39,8 @@ export const subjects = [
     remove: {
       delete: `
         ?subject ?sp ?so .
+        ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+        ?article ?ap ?ao .
         ?formdata ?fp ?fo .
         ?remotefile ?ro ?rp .
         ?localfile ?lp ?lo .
@@ -49,6 +51,10 @@ export const subjects = [
         } UNION {
           ?subject <http://www.w3.org/ns/prov#generated> ?formdata .
           ?formdata ?fp ?fo .
+        } UNION {
+          ?subject <http://purl.org/dc/terms/subject> ?submissionDocument .
+          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+          ?article ?ap ?ao .
         } UNION {
           ?subject <http://www.w3.org/ns/prov#generated> ?formdata .
           ?formdata <http://purl.org/dc/terms/hasPart> ?remotefile .
@@ -64,6 +70,8 @@ export const subjects = [
     copy: {
       insert: `
         ?subject ?sp ?so .
+        ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+        ?article ?ap ?ao .
         ?formdata ?fp ?fo .
         ?remotefile ?ro ?rp .
         ?localfile ?lp ?lo .
@@ -74,6 +82,10 @@ export const subjects = [
         } UNION {
           ?subject <http://www.w3.org/ns/prov#generated> ?formdata .
           ?formdata ?fp ?fo .
+        } UNION {
+          ?subject <http://purl.org/dc/terms/subject> ?submissionDocument .
+          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+          ?article ?ap ?ao .
         } UNION {
           ?subject <http://www.w3.org/ns/prov#generated> ?formdata .
           ?formdata <http://purl.org/dc/terms/hasPart> ?remotefile .
@@ -148,6 +160,8 @@ export const subjects = [
     remove: {
       delete: `
         ?submission ?sp ?so .
+        ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+        ?article ?ap ?ao .
         ?subject ?fp ?fo .
         ?remotefile ?ro ?rp .
         ?localfile ?lp ?lo .
@@ -158,6 +172,11 @@ export const subjects = [
           ?submission ?sp ?so .
         } UNION {
           ?subject ?fp ?fo .
+        } UNION {
+          ?submission <http://www.w3.org/ns/prov#generated> ?subject .
+          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
+          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+          ?article ?ap ?ao .
         } UNION {
           ?subject <http://purl.org/dc/terms/hasPart> ?remotefile .
           ?remotefile ?ro ?rp .
@@ -171,6 +190,8 @@ export const subjects = [
     copy: {
       insert: `
         ?submission ?sp ?so .
+        ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+        ?article ?ap ?ao .
         ?subject ?fp ?fo .
         ?remotefile ?ro ?rp .
         ?localfile ?lp ?lo .
@@ -181,6 +202,11 @@ export const subjects = [
           ?submission ?sp ?so .
         } UNION {
           ?subject ?fp ?fo .
+        } UNION {
+          ?submission <http://www.w3.org/ns/prov#generated> ?subject .
+          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
+          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+          ?article ?ap ?ao .
         } UNION {
           ?subject <http://purl.org/dc/terms/hasPart> ?remotefile .
           ?remotefile ?ro ?rp .
@@ -260,6 +286,8 @@ export const subjects = [
     remove: {
       delete: `
         ?submission ?sp ?so .
+        ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+        ?article ?ap ?ao .
         ?formdata ?fp ?fo .
         ?subject ?ro ?rp .
         ?localfile ?lp ?lo .
@@ -272,6 +300,12 @@ export const subjects = [
         } UNION {
           ?formdata <http://purl.org/dc/terms/hasPart> ?subject .
           ?formdata ?fp ?fo .
+        } UNION {
+          ?submission <http://www.w3.org/ns/prov#generated> ?formdata .
+          ?formdata <http://purl.org/dc/terms/hasPart> ?subject .
+          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
+          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+          ?article ?ap ?ao .
         } UNION {
           ?subject ?ro ?rp .
         } UNION {
@@ -283,6 +317,8 @@ export const subjects = [
     copy: {
       insert: `
         ?submission ?sp ?so .
+        ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+        ?article ?ap ?ao .
         ?formdata ?fp ?fo .
         ?subject ?ro ?rp .
         ?localfile ?lp ?lo .
@@ -295,6 +331,12 @@ export const subjects = [
         } UNION {
           ?formdata <http://purl.org/dc/terms/hasPart> ?subject .
           ?formdata ?fp ?fo .
+        } UNION {
+          ?submission <http://www.w3.org/ns/prov#generated> ?formdata .
+          ?formdata <http://purl.org/dc/terms/hasPart> ?subject .
+          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
+          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+          ?article ?ap ?ao .
         } UNION {
           ?subject ?ro ?rp .
         } UNION {
@@ -372,6 +414,8 @@ export const subjects = [
     remove: {
       delete: `
         ?submission ?sp ?so .
+        ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+        ?article ?ap ?ao .
         ?formdata ?fp ?fo .
         ?remotefile ?ro ?rp .
         ?subject ?lp ?lo .
@@ -386,6 +430,13 @@ export const subjects = [
           ?formdata <http://purl.org/dc/terms/hasPart> ?remotefile .
           ?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource> ?remotefile .
           ?formdata ?fp ?fo .
+        } UNION {
+          ?submission <http://www.w3.org/ns/prov#generated> ?formdata .
+          ?formdata <http://purl.org/dc/terms/hasPart> ?remotefile .
+          ?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource> ?remotefile .
+          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
+          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+          ?article ?ap ?ao .
         } UNION {
           ?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource> ?remotefile .
           ?remotefile ?ro ?rp .
@@ -397,6 +448,8 @@ export const subjects = [
     copy: {
       insert: `
         ?submission ?sp ?so .
+        ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+        ?article ?ap ?ao .
         ?formdata ?fp ?fo .
         ?remotefile ?ro ?rp .
         ?subject ?lp ?lo .
@@ -411,6 +464,13 @@ export const subjects = [
           ?formdata <http://purl.org/dc/terms/hasPart> ?remotefile .
           ?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource> ?remotefile .
           ?formdata ?fp ?fo .
+        } UNION {
+          ?submission <http://www.w3.org/ns/prov#generated> ?formdata .
+          ?formdata <http://purl.org/dc/terms/hasPart> ?remotefile .
+          ?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource> ?remotefile .
+          ?submission <http://purl.org/dc/terms/subject> ?submissionDocument .
+          ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?article .
+          ?article ?ap ?ao .
         } UNION {
           ?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource> ?remotefile .
           ?remotefile ?ro ?rp .


### PR DESCRIPTION
[DL-5837]

The VDDS should also include data about the `besluit:Artikel` and a link to that entity in the vendor graphs.

The link from to the Artikel from the Submission is through the SubmissonDocument, but we don't want data for the SubmissionDocument in the vendor graphs.

**Testing**

Use the test procedure described at https://github.com/lblod/app-digitaal-loket/pull/575

Make sure you have the producer-consumer-connection between your local `app-digitaal-loket` and `app-worship-decisions-database` running.