### PR TITLE
Bump `submissions-dispatcher`: fix for documents "Budget(wijziging)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@
 - frontend v0.12.0: https://github.com/lblod/frontend-worship-decisions/blob/master/CHANGELOG.md#0120-2024-06-19
 - Bump `submissions-dispatcher` to v0.15.1 to improve healing. (DL-5895)
   * This healing is faster and does not remove and re-insert all the data for every submission. It is much more selective.
+- Bump `submissions-dispatcher` to v0.15.2 to fix dispatching "Budget(wijziging)" Submission types. (DL-5997)
 
 ### Deploy notes
 - `drc up -d frontend search-query-management`
 - `drc restart resource cache`
+- Run (new and improved) healing on the `submissions-dispatcher`.
+  * `drc exec submissions-dispatcher bash`
+  * `apk add curl`
+  * `curl -X GET http://localhost/heal-submission`
 
 ## 0.26.1 (2024-05-29)
   - Fix custom info label field in forms LEKP-rapport - Melding correctie authentieke bron and LEKP-rapport - Toelichting Lokaal Bestuur (DL-5934)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,7 @@ services:
     restart: always
     logging: *default-logging
   submissions-dispatcher:
-    image: lblod/worship-submissions-graph-dispatcher-service:0.15.1
+    image: lblod/worship-submissions-graph-dispatcher-service:0.15.2
     environment:
       ORG_GRAPH_SUFFIX: "LoketLB-databankEredienstenGebruiker"
       SUDO_QUERY_RETRY: "true"


### PR DESCRIPTION
**[DL-5997]**

Fix for the Budget(wijziging) document in the `submissions-dispatcher`.
See https://github.com/lblod/worship-submissions-graph-dispatcher-service/pull/24