### PR TITLE
Repair some OP public data for "toezichthoudende provincie"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bump `submissions-dispatcher` to v0.15.1 to improve healing. (DL-5895)
   * This healing is faster and does not remove and re-insert all the data for every submission. It is much more selective.
 - Bump `submissions-dispatcher` to v0.15.2 to fix dispatching "Budget(wijziging)" Submission types. (DL-5997)
+- Link Toezichthoudende Provincie Antwerpen to "Orthodoxe Parochie Heilige Sophrony de Athoniet" (DL-6014)
 
 ### Deploy notes
 - `drc up -d frontend search-query-management`
@@ -15,6 +16,10 @@
   * `drc exec submissions-dispatcher bash`
   * `apk add curl`
   * `curl -X GET http://localhost/heal-submission`
+- Not needed because healing will take core of this, but on a time budget you could do:
+  * `drc exec submissions-dispatcher bash`
+  * `apk add curl`
+  * `curl -X GET http://localhost/heal-submission?subject=http://data.lblod.info/submissions/66311321F0F686D7CD7EFB29`
 
 ## 0.26.1 (2024-05-29)
   - Fix custom info label field in forms LEKP-rapport - Melding correctie authentieke bron and LEKP-rapport - Toelichting Lokaal Bestuur (DL-5934)

--- a/config/migrations/2024/20240723185100-op-public-data-sophroniet-repair.sparql
+++ b/config/migrations/2024/20240723185100-op-public-data-sophroniet-repair.sparql
@@ -1,0 +1,12 @@
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/bestuurseenheden/bd74ee38a4b1e296821a11729c1f704cf439576c7ab2c910c95b067cf183d923> <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/66716592A87E31723DA31871> .
+    <http://data.lblod.info/id/bestuurseenheden/bd74ee38a4b1e296821a11729c1f704cf439576c7ab2c910c95b067cf183d923> <http://www.w3.org/ns/regorg#legalName> "Antwerpen" .
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/66716592A87E31723DA31871> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen> .
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/66716592A87E31723DA31871> <http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100.0 .
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/66716592A87E31723DA31871> <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1> .
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/66716592A87E31723DA31871> <http://mu.semte.ch/vocabularies/core/uuid> "66716592A87E31723DA31871" .
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/66716592A87E31723DA31871> <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/besturenVanDeEredienst/6564B9CA6DEE214B7207D427> .
+  }
+}
+


### PR DESCRIPTION
**[DL-6014]**

This migration links the "Provincie Antwerpen" to the "Orthodoxe Parochie Heilige Sophrony de Athoniet" as Toezichthoudend unit.

Tested succesfully that a Submission posted by "Orthodoxe Parochie Heilige Sophrony de Athoniet" is actually dispatched to the province.