### PR TITLE
Bump cross reference service and dispatcher

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -171,8 +171,8 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/concepts/"
   end
 
-  get "/related-document-information/*path" do
-    forward conn, path, "http://worship-decisions-cross-reference/related-document-information/"
+  get "/worship-decisions-cross-reference/document-information/*path" do
+    forward conn, path, "http://worship-decisions-cross-reference/document-information/"
   end
 
   #################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,7 @@ services:
     restart: always
     logging: *default-logging
   worship-decisions-cross-reference:
-    image: lblod/worship-decisions-cross-reference-service:0.4.0
+    image: lblod/worship-decisions-cross-reference-service:0.4.2
     environment:
       SCOPE_SUBMISSIONS_TO_ONE_GRAPH: "true"
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,9 @@ services:
     restart: always
     logging: *default-logging
   worship-decisions-cross-reference:
-    image: lblod/worship-decisions-cross-reference-service:0.3.1
+    image: lblod/worship-decisions-cross-reference-service:0.4.0
+    environment:
+      SCOPE_SUBMISSIONS_TO_ONE_GRAPH: "true"
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
# Context

DL-6307

:warning: The flag `SCOPE_SUBMISSIONS_TO_ONE_GRAPH` comes from https://github.com/lblod/worship-decisions-cross-reference-service/pull/4 . Once the service PR is merged, I'll bump `worship-decisions-cross-reference-service` here. :warning:  

# Testing instructions

To be tested with https://github.com/lblod/frontend-worship-decisions/pull/27, see instructions there.