### PR TITLE
Feature/abb sub group destinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ drc up -d submissions-dispatcher
 drc exec submissions-dispatcher curl http://localhost/heal-submission
 ```
 
-Then kick in the healing.
+This last command starts the healing of all submissions. This will take a long
+while. Check the logs of the `submission-dispatcher` for its process.
+
+```
+docker compose logs --tail 1000 -f submissions-dispatcher
+```
 
 ## v0.33.0 (2025-06-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,23 @@
 # Changelog
+
 ## Unreleased
+
 ### General
- - Bump updated version from `submissions-dispatcher`. See also [DL-6512]
-   - In essence: extra complication in the dispatch rules. If ABB is a destinator, we need to split the dispatching between "default" and "ABB-LF".
-   - See also: https://github.com/lblod/worship-submissions-graph-dispatcher-service/pull/31
-   - Added new ABB mock user with this right only
+
+- Bump updated version from `submissions-dispatcher`. See also [DL-6512]
+  - In essence: extra complication in the dispatch rules. If ABB is a destinator, we need to split the dispatching between "default" and "ABB-LF".
+  - See also: https://github.com/lblod/worship-submissions-graph-dispatcher-service/pull/31
+  - Added new ABB mock user with this right only
 
 ### Deploy Notes
+
 ```
 drc restart migrations
 drc up -d submissions-dispatcher
 drc exec submissions-dispatcher curl http://localhost/heal-submission
 ```
-Then kick in the healing
+
+Then kick in the healing.
 
 ## v0.33.0 (2025-06-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+## Unreleased
+### General
+ - Bump updated version from `submissions-dispatcher`. See also [DL-6512]
+   - In essence: extra complication in the dispatch rules. If ABB is a destinator, we need to split the dispatching between "default" and "ABB-LF".
+   - See also: https://github.com/lblod/worship-submissions-graph-dispatcher-service/pull/31
+   - Added new ABB mock user with this right only
+
+### Deploy Notes
+```
+drc restart migrations
+drc up -d submissions-dispatcher
+drc exec submissions-dispatcher curl http://localhost/heal-submission
+```
+Then kick in the healing
 
 ## v0.33.0 (2025-06-04)
 

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -163,6 +163,32 @@ defmodule Acl.UserGroups.Config do
                         "http://www.w3.org/ns/prov#Location"
                       ]
                     } } ] },
+      %GroupSpec{
+        name: "readers",
+        useage: [:read],
+      access: access_by_role("LoketLB-databankEredienstenGebruiker-LF"),
+        graphs: [ %GraphSpec{
+                    graph: "http://mu.semte.ch/graphs/organizations/",
+                    constraint: %ResourceConstraint{
+                      resource_types: [
+                        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
+                        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject",
+                        "http://xmlns.com/foaf/0.1/Document",
+                        "http://rdf.myexperiment.org/ontologies/base/Submission",
+                        "http://mu.semte.ch/vocabularies/ext/SubmissionDocument",
+                        "http://lblod.data.gift/vocabularies/automatische-melding/FormData",
+                        "http://xmlns.com/foaf/0.1/Person",
+                        "http://xmlns.com/foaf/0.1/OnlineAccount",
+                        "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
+                        "http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode",
+                        "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
+                        "http://mu.semte.ch/vocabularies/ext/BestuursorgaanClassificatieCode",
+                        "http://mu.semte.ch/vocabularies/ext/AuthenticityType",
+                        "http://www.w3.org/2004/02/skos/core#ConceptScheme",
+                        "http://www.w3.org/2004/02/skos/core#Concept",
+                        "http://www.w3.org/ns/prov#Location"
+                      ]
+                    } } ] },
       # // Admin users
       %GroupSpec{
         name: "o-admin-sessions-rwf",

--- a/config/migrations/2025/20250605134907-add-lf-mock-user.sparql
+++ b/config/migrations/2025/20250605134907-add-lf-mock-user.sparql
@@ -1,0 +1,53 @@
+# This creates a mock user for ABB with LF session role
+# The update-mock-login-service doesn't support 2 distinct mock users for the same organizations
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?persoon a foaf:Person;
+           mu:uuid ?uuidPersoon;
+           foaf:firstName "LF departement van";
+           foaf:familyName "ABB";
+           foaf:member ?bestuurseenheid;
+           foaf:account ?account.
+  ?account a foaf:OnlineAccount;
+           mu:uuid ?uuidAccount;
+           foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
+           ext:sessionRole "LoketLB-databankEredienstenGebruiker-LF".
+           }
+  GRAPH ?g {
+  ?persoon a foaf:Person;
+           mu:uuid ?uuidPersoon;
+           foaf:firstName "LF departement van";
+           foaf:familyName "ABB";
+           foaf:member ?bestuurseenheid;
+           foaf:account ?account.
+  ?account a foaf:OnlineAccount;
+           mu:uuid ?uuidAccount;
+           foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
+           ext:sessionRole "LoketLB-databankEredienstenGebruiker-LF".
+          }
+}
+WHERE {
+     ?bestuurseenheid a besluit:Bestuurseenheid;
+     mu:uuid ?uuid;
+     skos:prefLabel ?naam;
+     besluit:classificatie/skos:prefLabel ?classificatie.
+
+     BIND(CONCAT(?classificatie, " ", ?naam, "als LF") as ?volledigeNaam)
+     BIND(MD5(?volledigeNaam) as ?uuidPersoon)
+     BIND(MD5(CONCAT(?volledigeNaam,"ACCOUNT")) as ?uuidAccount)
+     BIND(IRI(CONCAT("http://data.lblod.info/id/persoon/", ?uuidPersoon)) AS ?persoon)
+     BIND(IRI(CONCAT("http://data.lblod.info/id/account/", ?uuidAccount)) AS ?account)
+     BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/",?uuid)) AS ?g )
+
+     VALUES ?bestuurseenheid  {
+       <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
+     }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
     restart: always
     logging: *default-logging
   submissions-dispatcher:
-    image: lblod/worship-submissions-graph-dispatcher-service:0.17.0-abb-sub-group-destinators-rc-1
+    image: lblod/worship-submissions-graph-dispatcher-service:0.17.0
     environment:
       ORG_GRAPH_SUFFIX: "LoketLB-databankEredienstenGebruiker"
       SUDO_QUERY_RETRY: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
     restart: always
     logging: *default-logging
   submissions-dispatcher:
-    image: lblod/worship-submissions-graph-dispatcher-service:0.16.7
+    image: lblod/worship-submissions-graph-dispatcher-service:0.17.0-abb-sub-group-destinators-rc-1
     environment:
       ORG_GRAPH_SUFFIX: "LoketLB-databankEredienstenGebruiker"
       SUDO_QUERY_RETRY: "true"


### PR DESCRIPTION
⚠️ Don't merge as long as ACM is not ready.

Context: See also: DL-6512
For the full explanation of the change: [GitHub PR #31](https://github.com/lblod/worship-submissions-graph-dispatcher-service/pull/31)

What the PR does:
- Adds an ABB mock user with separate LF access rights.
- Updates authorization rules with LF access rights.
- Bumps submission-dispatcher to an `rc`-tagged build (for ease of testing).

# Testing
It's best to have some data at hand. (You can `scp` from QA; there should even be a tar file ready for you.)
An image is build, so `drc up` is possible.

## Method One
The lazy and wait approach (took me an hour). You can follow the deploy notes and wait for the healing to finish.

Once done, you can log in as a 'normal ABB' and look for:
- [Erkenning regulier procedure](https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73)
- [Samenvoeging](https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a)

If you have the QA data, as a normal ABB user, you should see some submissions.
If you log in as `LF departement van ABB`, you should not see these submissions (but the data should still be there).

## Method Two
The quick one, but fiddly one.

In `docker-compose.override.yml`
```
services:
  submissions-dispatcher:
    environment:
      ENABLE_HEALING: "false"
      NUMBER_OF_HEALING_QUEUES: 3
    ports:
      - 8889:80
```

Forbidden for submissions for `LF departement van ABB`,
```
 SELECT DISTINCT ?s ?uuid {
   VALUES ?typeDossier {
    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73>
    <https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a>
   }

   ?s a <http://rdf.myexperiment.org/ontologies/base/Submission>;
     <http://mu.semte.ch/vocabularies/core/uuid> ?uuid;
     <http://www.w3.org/ns/prov#generated> ?formData.

   ?formData <http://purl.org/dc/terms/type> ?typeDossier.
 }
 LIMIT 5
```
Then `curl http://localhost:8889/heal-submission?subject=http://data.lblod.info/submissions/....`

It should not arrive if logged in as `LF departement van ABB`.

Of course, check if things still arrive for the allowed submissions.
E.g
```
 SELECT DISTINCT ?s ?uuid {
   VALUES ?typeDossier {
    <https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c> # Advies jaarrekening
   }

   ?s a <http://rdf.myexperiment.org/ontologies/base/Submission>;
     <http://mu.semte.ch/vocabularies/core/uuid> ?uuid;
     <http://www.w3.org/ns/prov#generated> ?formData.

   ?formData <http://purl.org/dc/terms/type> ?typeDossier.
 }
 LIMIT 5
```


