### PR TITLE
[DL-7354] Fix a mail delivery issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 
 - Bump acm-login service [DL-7346]
 - Bump submissions-dispatcher [DL-7352]
+- fix an issue with emails getting stuck in the "sending" folder due [DL-7339], [DL-7354]
 
 ### Deploy instructions
 
 ```
-drc up -d login login-dashboard submissions-dispatcher
+drc up -d login login-dashboard submissions-dispatcher deliver-email-service
 ```
 ## v0.39.3 (2026-05-13)
 - Update `frontend` to version [`v0.18.0`](https://github.com/lblod/frontend-worship-decisions/releases/tag/v0.18.0)

--- a/config/migrations/2026/20260521131100-move-old-stuck-emails.sparql
+++ b/config/migrations/2026/20260521131100-move-old-stuck-emails.sparql
@@ -1,0 +1,15 @@
+PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE {
+  ?email nmo:isPartOf <http://data.lblod.info/id/mail-folders/4> .
+}
+INSERT {
+  ?email nmo:isPartOf <http://data.lblod.info/id/mail-folders/6> .
+}
+WHERE {
+  ?email a nmo:Email ;
+         nmo:isPartOf <http://data.lblod.info/id/mail-folders/4> ;
+         nmo:sentDate ?sentDate .
+  FILTER(?sentDate < (NOW() - "P30D"^^xsd:duration))
+}

--- a/config/migrations/2026/20260521151500-reset-mail-retry-count.sparql
+++ b/config/migrations/2026/20260521151500-reset-mail-retry-count.sparql
@@ -1,0 +1,14 @@
+PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE {
+  ?email <http://redpencil.data.gift/vocabularies/tasks/numberOfRetries> ?retryCount .
+}
+INSERT {
+  ?email <http://redpencil.data.gift/vocabularies/tasks/numberOfRetries> "0"^^xsd:integer .
+}
+WHERE {
+  ?email a nmo:Email ;
+         nmo:isPartOf <http://data.lblod.info/id/mail-folders/4> ;
+         <http://redpencil.data.gift/vocabularies/tasks/numberOfRetries> ?retryCount .
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -314,7 +314,7 @@ services:
       - "logging=true"
     logging: *default-logging
   deliver-email-service:
-    image: redpencil/deliver-email-service:1.0.0
+    image: redpencil/deliver-email-service:1.0.1
     environment:
       MAILBOX_URI: "http://data.lblod.info/id/mailboxes/1"
     labels:


### PR DESCRIPTION
We use Outlook as the SMTP service, which has a limit of 30 mails/minute which we sometimes run into. We do retry sending the mails but due to a bug in the mail service retries were only done if the mail was newer than 30 minutes, which resulted in max 3 retries with our cronjob pattern.

The fixed service should retry correctly,  if the mail is older than 30 minutes. This means we also need to clean up the old mails that are stuck in the sending folder. We do want to retry all mails from the last 30 days, however.