### PR TITLE
Optimisation: source graphs for VDDS

### DIFF
--- a/config/vendor-data/model.ttl
+++ b/config/vendor-data/model.ttl
@@ -43,6 +43,8 @@ meb:Submission
         mu:uuid ?organisationUuid .
     }
   """ ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-databankEredienstenGebruiker" ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-databankEredienstenGebruiker-LF" ;
   vdds:targetGraphTemplate "http://mu.semte.ch/graphs/vendors/${vendorUuid}/${organisationUuid}" .
 
 ext:SubmissionDocument

--- a/config/vendor-data/model.ttl
+++ b/config/vendor-data/model.ttl
@@ -27,7 +27,7 @@
 
 meb:Submission
   rdf:type vdds:Class ;
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       GRAPH ?g {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -358,7 +358,7 @@ services:
     restart: always
     logging: *default-logging
   vendor-data-distribution:
-    image: lblod/vendor-data-distribution-service:2.0.0
+    image: lblod/vendor-data-distribution-service:2.2.0
     environment:
       LOGLEVEL: "info"
       WRITE_ERRORS: "true"


### PR DESCRIPTION
Part of **[DL-7378]**

This PR makes source data selection more careful. This could make the VDDS slightly more efficient, but mostly more correct as we are not just selecting from the whole triplestore, but rather from the specific organisation graphs that hold the data for that vendor.

In the past, the VDDS could copy data from any organisation (including vendor graphs for those organisations). Normally this is no problem, because Submission data is always properly contained within one organisation. Therefore this optimisation might be redundant, but can still be a good thing to have.