### PR TITLE
DL-7422: changed the bestuurseenheid.sparql query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## Unreleased
+- Bump submissions-dispatcher [DL-7417].
+  - Ensure child submissions are forwarded to ABB/LF
+
+### Deploy notes
+```
+drc up -d submissions-dispatcher
+```
 
 ## v0.39.6 (2026-05-28)
 

--- a/config/delta-consumers/op-consumer/mapping/queries/op2dl/mapping/bestuurseenheid.sparql
+++ b/config/delta-consumers/op-consumer/mapping/queries/op2dl/mapping/bestuurseenheid.sparql
@@ -5,11 +5,11 @@ CONSTRUCT {
   ?s skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
     skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
 } WHERE {
-  VALUES ?classification {
-    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
-    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
-  }
-
   ?s a besluit:Bestuurseenheid;
      <http://www.w3.org/ns/org#classification> ?classification.
+
+  VALUES ?classification {
+      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
+      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,7 +193,7 @@ services:
     restart: always
     logging: *default-logging
   submissions-dispatcher:
-    image: lblod/worship-submissions-graph-dispatcher-service:0.18.1
+    image: lblod/worship-submissions-graph-dispatcher-service:0.19.0
     environment:
       ORG_GRAPH_SUFFIX: "LoketLB-databankEredienstenGebruiker"
       SUDO_QUERY_RETRY: "true"


### PR DESCRIPTION
To sidestep the bug in the delta-consumer code (https://github.com/lblod/delta-consumer/pull/46), I made a change to bestuurseenheid.sparql to not put the VALUES{} clause first.

TO TEST:
    rsync with dev
    drc up -d and check that the delta-consumer doesn't get stuck anymore
