### PR TITLE
Fix/dl 7422 bugfix bestuurseenheid mapping

### DIFF
--- a/config/delta-consumers/op-consumer/mapping/queries/op2dl/mapping/bestuurseenheid.sparql
+++ b/config/delta-consumers/op-consumer/mapping/queries/op2dl/mapping/bestuurseenheid.sparql
@@ -5,11 +5,11 @@ CONSTRUCT {
   ?s skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
     skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
 } WHERE {
-  VALUES ?classification {
-    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
-    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
-  }
-
   ?s a besluit:Bestuurseenheid;
      <http://www.w3.org/ns/org#classification> ?classification.
+
+  VALUES ?classification {
+      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
+      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
+  }
 }


### PR DESCRIPTION
To sidestep the bug in the delta-consumer code (https://github.com/lblod/delta-consumer/pull/46), I made a change to bestuurseenheid.sparql to not put the VALUES{} clause first.

TO TEST:
rsync with dev
drc up -d and check that the delta-consumer doesn't get stuck anymore